### PR TITLE
`int` errno-like -> `ocvsmd::sdk::ErrorCode`

### DIFF
--- a/include/ocvsmd/sdk/defines.hpp
+++ b/include/ocvsmd/sdk/defines.hpp
@@ -8,12 +8,34 @@
 
 #include <cetl/pf20/cetlpf.hpp>
 
+#include <cerrno>
 #include <cstdint>
 
 namespace ocvsmd
 {
 namespace sdk
 {
+
+/// Defines some common error codes of IPC operations.
+///
+/// Maps to `errno` values, hence `std::int32_t` inheritance and zero on success.
+///
+enum class ErrorCode : std::int32_t  // NOLINT
+{
+    Success             = 0,
+    Busy                = EBUSY,
+    NoEntry             = ENOENT,
+    TimedOut            = ETIMEDOUT,
+    OutOfMemory         = ENOMEM,
+    AlreadyExists       = EEXIST,
+    InvalidArgument     = EINVAL,
+    Canceled            = ECANCELED,
+    NotConnected        = ENOTCONN,
+    Disconnected        = ECONNRESET,
+    Shutdown            = ESHUTDOWN,
+    OperationInProgress = EINPROGRESS,
+
+};  // ErrorCode
 
 /// Defines the type of the Cyphal node ID.
 ///

--- a/include/ocvsmd/sdk/file_server.hpp
+++ b/include/ocvsmd/sdk/file_server.hpp
@@ -6,6 +6,7 @@
 #ifndef OCVSMD_SDK_FILE_SERVER_HPP_INCLUDED
 #define OCVSMD_SDK_FILE_SERVER_HPP_INCLUDED
 
+#include "defines.hpp"
 #include "execution.hpp"
 
 #include <cetl/pf17/cetlpf.hpp>
@@ -46,7 +47,7 @@ public:
     struct ListRoots final
     {
         using Success = std::vector<std::string>;
-        using Failure = int;  // `errno`-like error code
+        using Failure = ErrorCode;
         using Result  = cetl::variant<Success, Failure>;
     };
     virtual SenderOf<ListRoots::Result>::Ptr listRoots() = 0;
@@ -61,7 +62,7 @@ public:
     struct PopRoot final
     {
         using Success = cetl::monostate;  // like `void`
-        using Failure = int;              // `errno`-like error code
+        using Failure = ErrorCode;
         using Result  = cetl::variant<Success, Failure>;
     };
     /// Removes a root directory from the list of directories that the file server will serve.
@@ -85,7 +86,7 @@ public:
     struct PushRoot final
     {
         using Success = cetl::monostate;  // like `void`
-        using Failure = int;              // `errno`-like error code
+        using Failure = ErrorCode;
         using Result  = cetl::variant<Success, Failure>;
     };
     /// Adds a new root directory to the list of directories that the file server will serve.

--- a/include/ocvsmd/sdk/node_command_client.hpp
+++ b/include/ocvsmd/sdk/node_command_client.hpp
@@ -41,14 +41,21 @@ public:
     /// Defines the result type of the command execution.
     ///
     /// On success, the result is a map of node IDs to their responses (`status` and `output` params).
-    /// Missing Cyphal nodes (or failed to respond in a given timeout) are not included in the map.
+    /// On failure, the result is an error code.
     ///
     struct Command final
     {
-        using NodeRequest  = uavcan::node::ExecuteCommand_1_3::Request;
-        using NodeResponse = uavcan::node::ExecuteCommand_1_3::Response;
+        using NodeRequest = uavcan::node::ExecuteCommand_1_3::Request;
+        struct NodeResponse final
+        {
+            using Success = uavcan::node::ExecuteCommand_1_3::Response;
+            using Failure = int;  // `errno`-like error code.
+            using Result  = cetl::variant<Success, Failure>;
 
-        using Success = std::unordered_map<CyphalNodeId, NodeResponse>;
+            NodeResponse() = delete;
+        };
+
+        using Success = std::unordered_map<CyphalNodeId, NodeResponse::Result>;
         using Failure = int;  // `errno`-like error code.
         using Result  = cetl::variant<Success, Failure>;
 

--- a/include/ocvsmd/sdk/node_command_client.hpp
+++ b/include/ocvsmd/sdk/node_command_client.hpp
@@ -49,14 +49,14 @@ public:
         struct NodeResponse final
         {
             using Success = uavcan::node::ExecuteCommand_1_3::Response;
-            using Failure = int;  // `errno`-like error code.
+            using Failure = ErrorCode;
             using Result  = cetl::variant<Success, Failure>;
 
             NodeResponse() = delete;
         };
 
         using Success = std::unordered_map<CyphalNodeId, NodeResponse::Result>;
-        using Failure = int;  // `errno`-like error code.
+        using Failure = ErrorCode;
         using Result  = cetl::variant<Success, Failure>;
 
         Command() = delete;

--- a/include/ocvsmd/sdk/node_registry_client.hpp
+++ b/include/ocvsmd/sdk/node_registry_client.hpp
@@ -57,14 +57,14 @@ public:
         struct NodeRegisters final
         {
             using Success = std::vector<std::string>;
-            using Failure = int;  // `errno`-like error code.
+            using Failure = ErrorCode;
             using Result  = cetl::variant<Success, Failure>;
 
             NodeRegisters() = delete;
         };
 
         using Success = std::unordered_map<CyphalNodeId, NodeRegisters::Result>;
-        using Failure = int;  // `errno`-like error code.
+        using Failure = ErrorCode;
         using Result  = cetl::variant<Success, Failure>;
 
         List() = delete;
@@ -93,14 +93,14 @@ public:
         SenderOf<List::Result>::Ptr sender = list(node_ids, timeout);
         return then<List::NodeRegisters::Result, List::Result>(std::move(sender), [node_id](List::Result&& result) {
             //
-            if (auto* const err = cetl::get_if<List::Failure>(&result))
+            if (auto* const failure = cetl::get_if<List::Failure>(&result))
             {
-                return List::NodeRegisters::Result{*err};
+                return List::NodeRegisters::Result{*failure};
             }
             auto list = cetl::get<List::Success>(std::move(result));
 
             const auto node_it = list.find(node_id);
-            return (node_it != list.end()) ? std::move(node_it->second) : ENOENT;
+            return (node_it != list.end()) ? std::move(node_it->second) : ErrorCode::NoEntry;
         });
     }
 
@@ -126,8 +126,8 @@ public:
         ///
         struct RegKeyValueOrErr final
         {
-            std::string                  key;
-            cetl::variant<RegValue, int> value_or_err;  // `errno`-like error code.
+            std::string                        key;
+            cetl::variant<RegValue, ErrorCode> value_or_err;
         };
 
         /// Defines the result type of the list of a node registers.
@@ -138,14 +138,14 @@ public:
         struct NodeRegisters final
         {
             using Success = std::vector<RegKeyValueOrErr>;
-            using Failure = int;  // `errno`-like error code.
+            using Failure = ErrorCode;
             using Result  = cetl::variant<Success, Failure>;
 
             NodeRegisters() = delete;
         };
 
         using Success = std::unordered_map<CyphalNodeId, NodeRegisters::Result>;
-        using Failure = int;  // `errno`-like error code.
+        using Failure = ErrorCode;
         using Result  = cetl::variant<Success, Failure>;
 
         Access() = delete;
@@ -182,14 +182,14 @@ public:
             std::move(sender),
             [node_id](Access::Result&& access_result) {
                 //
-                if (auto* const err = cetl::get_if<Access::Failure>(&access_result))
+                if (auto* const failure = cetl::get_if<Access::Failure>(&access_result))
                 {
-                    return Access::NodeRegisters::Result{*err};
+                    return Access::NodeRegisters::Result{*failure};
                 }
                 auto list = cetl::get<Access::Success>(std::move(access_result));
 
                 const auto node_it = list.find(node_id);
-                return (node_it != list.end()) ? std::move(node_it->second) : ENOENT;
+                return (node_it != list.end()) ? std::move(node_it->second) : ErrorCode::NoEntry;
             });
     }
 
@@ -224,14 +224,14 @@ public:
             std::move(sender),
             [node_id](Access::Result&& access_result) {
                 //
-                if (auto* const err = cetl::get_if<Access::Failure>(&access_result))
+                if (auto* const failure = cetl::get_if<Access::Failure>(&access_result))
                 {
-                    return Access::NodeRegisters::Result{*err};
+                    return Access::NodeRegisters::Result{*failure};
                 }
                 auto list = cetl::get<Access::Success>(std::move(access_result));
 
                 const auto node_it = list.find(node_id);
-                return (node_it != list.end()) ? std::move(node_it->second) : ENOENT;
+                return (node_it != list.end()) ? std::move(node_it->second) : ErrorCode::NoEntry;
             });
     }
 

--- a/src/cli/fmt_helpers.hpp
+++ b/src/cli/fmt_helpers.hpp
@@ -16,6 +16,7 @@
 #include <spdlog/fmt/ranges.h>
 
 #include <string>
+#include <type_traits>
 
 template <>
 struct fmt::formatter<uavcan::_register::Value_1_0> : formatter<std::string>
@@ -89,7 +90,7 @@ struct fmt::formatter<ocvsmd::sdk::ErrorCode> : formatter<std::string>
             error_name = "Disconnected";
             break;
         case ErrorCode::Shutdown:
-            error_name = "NotConnected";
+            error_name = "Shutdown";
             break;
         case ErrorCode::OperationInProgress:
             error_name = "OperationInProgress";
@@ -98,7 +99,7 @@ struct fmt::formatter<ocvsmd::sdk::ErrorCode> : formatter<std::string>
             error_name = "ErrorCode";
             break;
         }
-        return format_to(ctx.out(), "{}({})", error_name, static_cast<std::int32_t>(error_code));
+        return format_to(ctx.out(), "{}({})", error_name, static_cast<std::underlying_type_t<ErrorCode>>(error_code));
     }
 };
 

--- a/src/cli/fmt_helpers.hpp
+++ b/src/cli/fmt_helpers.hpp
@@ -6,6 +6,8 @@
 #ifndef OCVSMD_CLI_FMT_HELPERS_HPP_INCLUDED
 #define OCVSMD_CLI_FMT_HELPERS_HPP_INCLUDED
 
+#include "ocvsmd/sdk/defines.hpp"
+
 #include <cetl/pf17/cetlpf.hpp>
 
 #include <uavcan/_register/Value_1_0.hpp>
@@ -41,6 +43,62 @@ public:
     static auto format(const uavcan::_register::Value_1_0& value, format_context& ctx)
     {
         return cetl::visit([&ctx](const auto& val) { return format_to(val, ctx); }, value.union_value);
+    }
+};
+
+template <>
+struct fmt::formatter<ocvsmd::sdk::ErrorCode> : formatter<std::string>
+{
+    auto format(const ocvsmd::sdk::ErrorCode error_code, format_context& ctx) const
+    {
+        using ocvsmd::sdk::ErrorCode;
+
+        if (error_code == ErrorCode::Success)
+        {
+            return format_to(ctx.out(), "Success");
+        }
+
+        const char* error_name = "ErrorCode";
+        switch (error_code)
+        {
+        case ErrorCode::Busy:
+            error_name = "Busy";
+            break;
+        case ErrorCode::NoEntry:
+            error_name = "NoEntry";
+            break;
+        case ErrorCode::TimedOut:
+            error_name = "TimedOut";
+            break;
+        case ErrorCode::OutOfMemory:
+            error_name = "OutOfMemory";
+            break;
+        case ErrorCode::AlreadyExists:
+            error_name = "AlreadyExists";
+            break;
+        case ErrorCode::InvalidArgument:
+            error_name = "InvalidArgument";
+            break;
+        case ErrorCode::Canceled:
+            error_name = "Canceled";
+            break;
+        case ErrorCode::NotConnected:
+            error_name = "NotConnected";
+            break;
+        case ErrorCode::Disconnected:
+            error_name = "Disconnected";
+            break;
+        case ErrorCode::Shutdown:
+            error_name = "NotConnected";
+            break;
+        case ErrorCode::OperationInProgress:
+            error_name = "OperationInProgress";
+            break;
+        default:
+            error_name = "ErrorCode";
+            break;
+        }
+        return format_to(ctx.out(), "{}({})", error_name, static_cast<std::int32_t>(error_code));
     }
 };
 

--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -17,7 +17,6 @@
 
 #include <spdlog/spdlog.h>
 
-#include <cerrno>
 #include <cstdlib>
 #include <cstring>
 #include <exception>

--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -271,9 +271,9 @@ int main(const int argc, const char** const argv)
             //
             auto sender      = registry->list(node_ids, std::chrono::seconds{1});
             auto list_result = ocvsmd::sdk::sync_wait<List::Result>(executor, std::move(sender));
-            if (const auto* const failure = cetl::get_if<List::Failure>(&list_result))
+            if (const auto* const list_failure = cetl::get_if<List::Failure>(&list_result))
             {
-                spdlog::error("Failed to list registers (err={}).", *failure);
+                spdlog::error("Failed to list registers (err={}).", *list_failure);
             }
             else
             {

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -12,7 +12,7 @@ set(dsdl_ocvsmd_files
         ${dsdl_ocvsmd_dir}/common/svc/file_server/PopRoot.0.1.dsdl
         ${dsdl_ocvsmd_dir}/common/svc/file_server/PushRoot.0.1.dsdl
         ${dsdl_ocvsmd_dir}/common/svc/node/AccessRegisters.0.1.dsdl
-        ${dsdl_ocvsmd_dir}/common/svc/node/ExecCmd.0.1.dsdl
+        ${dsdl_ocvsmd_dir}/common/svc/node/ExecCmd.0.2.dsdl
         ${dsdl_ocvsmd_dir}/common/svc/node/ListRegisters.0.1.dsdl
         ${dsdl_ocvsmd_dir}/common/svc/node/UavcanNodeExecCmdReq.0.1.dsdl
         ${dsdl_ocvsmd_dir}/common/svc/node/UavcanNodeExecCmdRes.0.1.dsdl

--- a/src/common/common_helpers.hpp
+++ b/src/common/common_helpers.hpp
@@ -6,6 +6,8 @@
 #ifndef OCVSMD_COMMON_HELPERS_HPP_INCLUDED
 #define OCVSMD_COMMON_HELPERS_HPP_INCLUDED
 
+#include "ocvsmd/sdk/defines.hpp"
+
 #include <spdlog/spdlog.h>
 
 #include <exception>
@@ -42,5 +44,63 @@ bool performWithoutThrowing(Action&& action) noexcept
 
 }  // namespace common
 }  // namespace ocvsmd
+
+// MARK: - Formatting
+
+// NOLINTBEGIN
+template <>
+struct fmt::formatter<ocvsmd::sdk::ErrorCode> : formatter<std::string>
+{
+    auto format(const ocvsmd::sdk::ErrorCode error_code, format_context& ctx) const
+    {
+        if (error_code == ocvsmd::sdk::ErrorCode::Success)
+        {
+            return format_to(ctx.out(), "Success");
+        }
+
+        const char* error_name = "ErrorCode";
+        switch (error_code)
+        {
+        case ocvsmd::sdk::ErrorCode::Busy:
+            error_name = "Busy";
+            break;
+        case ocvsmd::sdk::ErrorCode::NoEntry:
+            error_name = "NoEntry";
+            break;
+        case ocvsmd::sdk::ErrorCode::TimedOut:
+            error_name = "TimedOut";
+            break;
+        case ocvsmd::sdk::ErrorCode::OutOfMemory:
+            error_name = "OutOfMemory";
+            break;
+        case ocvsmd::sdk::ErrorCode::AlreadyExists:
+            error_name = "AlreadyExists";
+            break;
+        case ocvsmd::sdk::ErrorCode::InvalidArgument:
+            error_name = "InvalidArgument";
+            break;
+        case ocvsmd::sdk::ErrorCode::Canceled:
+            error_name = "Canceled";
+            break;
+        case ocvsmd::sdk::ErrorCode::NotConnected:
+            error_name = "NotConnected";
+            break;
+        case ocvsmd::sdk::ErrorCode::Disconnected:
+            error_name = "Disconnected";
+            break;
+        case ocvsmd::sdk::ErrorCode::Shutdown:
+            error_name = "NotConnected";
+            break;
+        case ocvsmd::sdk::ErrorCode::OperationInProgress:
+            error_name = "OperationInProgress";
+            break;
+        default:
+            error_name = "ErrorCode";
+            break;
+        }
+        return format_to(ctx.out(), "{}({})", error_name, static_cast<std::int32_t>(error_code));
+    }
+};
+// NOLINTEND
 
 #endif  // OCVSMD_COMMON_HELPERS_HPP_INCLUDED

--- a/src/common/common_helpers.hpp
+++ b/src/common/common_helpers.hpp
@@ -11,6 +11,7 @@
 #include <spdlog/spdlog.h>
 
 #include <exception>
+#include <type_traits>
 #include <utility>
 
 namespace ocvsmd
@@ -53,6 +54,8 @@ struct fmt::formatter<ocvsmd::sdk::ErrorCode> : formatter<std::string>
 {
     auto format(const ocvsmd::sdk::ErrorCode error_code, format_context& ctx) const
     {
+        using ocvsmd::sdk::ErrorCode;
+
         if (error_code == ocvsmd::sdk::ErrorCode::Success)
         {
             return format_to(ctx.out(), "Success");
@@ -61,44 +64,44 @@ struct fmt::formatter<ocvsmd::sdk::ErrorCode> : formatter<std::string>
         const char* error_name = "ErrorCode";
         switch (error_code)
         {
-        case ocvsmd::sdk::ErrorCode::Busy:
+        case ErrorCode::Busy:
             error_name = "Busy";
             break;
-        case ocvsmd::sdk::ErrorCode::NoEntry:
+        case ErrorCode::NoEntry:
             error_name = "NoEntry";
             break;
-        case ocvsmd::sdk::ErrorCode::TimedOut:
+        case ErrorCode::TimedOut:
             error_name = "TimedOut";
             break;
-        case ocvsmd::sdk::ErrorCode::OutOfMemory:
+        case ErrorCode::OutOfMemory:
             error_name = "OutOfMemory";
             break;
-        case ocvsmd::sdk::ErrorCode::AlreadyExists:
+        case ErrorCode::AlreadyExists:
             error_name = "AlreadyExists";
             break;
-        case ocvsmd::sdk::ErrorCode::InvalidArgument:
+        case ErrorCode::InvalidArgument:
             error_name = "InvalidArgument";
             break;
-        case ocvsmd::sdk::ErrorCode::Canceled:
+        case ErrorCode::Canceled:
             error_name = "Canceled";
             break;
-        case ocvsmd::sdk::ErrorCode::NotConnected:
+        case ErrorCode::NotConnected:
             error_name = "NotConnected";
             break;
-        case ocvsmd::sdk::ErrorCode::Disconnected:
+        case ErrorCode::Disconnected:
             error_name = "Disconnected";
             break;
-        case ocvsmd::sdk::ErrorCode::Shutdown:
-            error_name = "NotConnected";
+        case ErrorCode::Shutdown:
+            error_name = "Shutdown";
             break;
-        case ocvsmd::sdk::ErrorCode::OperationInProgress:
+        case ErrorCode::OperationInProgress:
             error_name = "OperationInProgress";
             break;
         default:
             error_name = "ErrorCode";
             break;
         }
-        return format_to(ctx.out(), "{}({})", error_name, static_cast<std::int32_t>(error_code));
+        return format_to(ctx.out(), "{}({})", error_name, static_cast<std::underlying_type_t<ErrorCode>>(error_code));
     }
 };
 // NOLINTEND

--- a/src/common/dsdl/ocvsmd/common/svc/node/ExecCmd.0.2.dsdl
+++ b/src/common/dsdl/ocvsmd/common/svc/node/ExecCmd.0.2.dsdl
@@ -6,6 +6,7 @@ UavcanNodeExecCmdReq.0.1 payload
 
 ---
 
+int32 error_code
 uint16 node_id
 UavcanNodeExecCmdRes.0.1 payload
 

--- a/src/common/dsdl_helpers.hpp
+++ b/src/common/dsdl_helpers.hpp
@@ -6,6 +6,8 @@
 #ifndef OCVSMD_COMMON_DSDL_HELPERS_HPP_INCLUDED
 #define OCVSMD_COMMON_DSDL_HELPERS_HPP_INCLUDED
 
+#include "ocvsmd/sdk/defines.hpp"
+
 #include <cetl/cetl.hpp>
 #include <cetl/pf20/cetlpf.hpp>
 
@@ -28,7 +30,7 @@ CETL_NODISCARD static auto tryDeserializePayload(const cetl::span<const std::uin
 }
 
 template <typename Message, typename Action>
-CETL_NODISCARD static int tryPerformOnSerialized(const Message& message, Action&& action)
+CETL_NODISCARD static sdk::ErrorCode tryPerformOnSerialized(const Message& message, Action&& action)
 {
     // Try to serialize the message to raw payload buffer.
     //
@@ -39,7 +41,7 @@ CETL_NODISCARD static int tryPerformOnSerialized(const Message& message, Action&
     const auto result_size = serialize(message, {buffer.data(), buffer.size()});
     if (!result_size)
     {
-        return EINVAL;
+        return sdk::ErrorCode::InvalidArgument;
     }
 
     const cetl::span<const std::uint8_t> bytes{buffer.data(), result_size.value()};
@@ -47,8 +49,9 @@ CETL_NODISCARD static int tryPerformOnSerialized(const Message& message, Action&
 }
 
 template <typename Message, std::size_t BufferSize, bool IsOnStack, typename Action>
-CETL_NODISCARD static auto tryPerformOnSerialized(const Message& message,
-                                                  Action&&       action) -> std::enable_if_t<IsOnStack, int>
+CETL_NODISCARD static auto tryPerformOnSerialized(  //
+    const Message& message,
+    Action&&       action) -> std::enable_if_t<IsOnStack, sdk::ErrorCode>
 {
     // Try to serialize the message to raw payload buffer.
     //
@@ -59,7 +62,7 @@ CETL_NODISCARD static auto tryPerformOnSerialized(const Message& message,
     const auto result_size = serialize(message, {buffer.data(), buffer.size()});
     if (!result_size)
     {
-        return EINVAL;
+        return sdk::ErrorCode::InvalidArgument;
     }
 
     const cetl::span<const std::uint8_t> bytes{buffer.data(), result_size.value()};
@@ -68,7 +71,7 @@ CETL_NODISCARD static auto tryPerformOnSerialized(const Message& message,
 
 template <typename Message, std::size_t BufferSize, bool IsOnStack, typename Action>
 CETL_NODISCARD static auto tryPerformOnSerialized(const Message& message,
-                                                  Action&&       action) -> std::enable_if_t<!IsOnStack, int>
+                                                  Action&&       action) -> std::enable_if_t<!IsOnStack, sdk::ErrorCode>
 {
     // Try to serialize the message to raw payload buffer.
     //
@@ -78,7 +81,7 @@ CETL_NODISCARD static auto tryPerformOnSerialized(const Message& message,
     const auto result_size = serialize(message, {buffer->data(), buffer->size()});
     if (!result_size)
     {
-        return EINVAL;
+        return sdk::ErrorCode::InvalidArgument;
     }
 
     const cetl::span<const std::uint8_t> bytes{buffer->data(), result_size.value()};

--- a/src/common/dsdl_helpers.hpp
+++ b/src/common/dsdl_helpers.hpp
@@ -12,7 +12,6 @@
 #include <cetl/pf20/cetlpf.hpp>
 
 #include <array>
-#include <cerrno>
 #include <cstddef>
 #include <cstdint>
 #include <memory>

--- a/src/common/io/io.cpp
+++ b/src/common/io/io.cpp
@@ -7,7 +7,6 @@
 
 #include "logging.hpp"
 
-#include <cerrno>
 #include <cstring>
 #include <unistd.h>
 

--- a/src/common/io/socket_address.cpp
+++ b/src/common/io/socket_address.cpp
@@ -8,6 +8,7 @@
 #include "io.hpp"
 #include "logging.hpp"
 #include "ocvsmd/platform/posix_utils.hpp"
+#include "ocvsmd/sdk/defines.hpp"
 
 #include <cetl/pf17/cetlpf.hpp>
 
@@ -122,7 +123,7 @@ SocketAddress::SocketResult::Var SocketAddress::socket(const int socket_type) co
     OwnFd out_fd;
 
     const auto& addr_generic = asGenericAddr();
-    if (const auto err = platform::posixSyscallError([this, socket_type, &addr_generic, &out_fd] {
+    if (const int err = platform::posixSyscallError([this, socket_type, &addr_generic, &out_fd] {
             //
             const int fd = ::socket(addr_generic.sa_family, socket_type, 0);
             if (fd != -1)
@@ -133,17 +134,17 @@ SocketAddress::SocketResult::Var SocketAddress::socket(const int socket_type) co
         }))
     {
         getLogger("io")->error("Failed to create socket: {}.", std::strerror(err));
-        return err;
+        return static_cast<sdk::ErrorCode>(err);
     }
 
-    if (const auto err = platform::posixSyscallError([&out_fd] {
+    if (const int err = platform::posixSyscallError([&out_fd] {
             //
             // NOLINTNEXTLINE(*-vararg)
             return ::fcntl(out_fd.get(), F_SETFL, O_NONBLOCK);
         }))
     {
         getLogger("io")->error("Failed to fcntl(O_NONBLOCK) socket: {}.", std::strerror(err));
-        return err;
+        return static_cast<sdk::ErrorCode>(err);
     }
 
     // Disable Nagle's algorithm for TCP sockets, so that our small IPC packets are sent immediately.
@@ -156,7 +157,7 @@ SocketAddress::SocketResult::Var SocketAddress::socket(const int socket_type) co
     return out_fd;
 }
 
-int SocketAddress::bind(const OwnFd& socket_fd) const
+sdk::ErrorCode SocketAddress::bind(const OwnFd& socket_fd) const
 {
     const int raw_fd = socket_fd.get();
     CETL_DEBUG_ASSERT(raw_fd != -1, "");
@@ -164,18 +165,18 @@ int SocketAddress::bind(const OwnFd& socket_fd) const
     // Disable IPv6-only mode for dual-stack sockets (aka wildcard).
     if (is_wildcard_)
     {
-        if (const auto err = platform::posixSyscallError([raw_fd] {
+        if (const int err = platform::posixSyscallError([raw_fd] {
                 //
-                int disable = 0;
+                constexpr int disable = 0;
                 return ::setsockopt(raw_fd, IPPROTO_IPV6, IPV6_V6ONLY, &disable, sizeof(disable));
             }))
         {
             getLogger("io")->error("Failed to set IPV6_V6ONLY=0: {}.", std::strerror(err));
-            return err;
+            return static_cast<sdk::ErrorCode>(err);
         }
     }
 
-    const auto err = platform::posixSyscallError([this, raw_fd] {
+    const int err = platform::posixSyscallError([this, raw_fd] {
         //
         return ::bind(raw_fd, &asGenericAddr(), addr_len_);
     });
@@ -183,15 +184,15 @@ int SocketAddress::bind(const OwnFd& socket_fd) const
     {
         getLogger("io")->error("Failed to bind socket: {}.", std::strerror(err));
     }
-    return err;
+    return static_cast<sdk::ErrorCode>(err);
 }
 
-int SocketAddress::connect(const OwnFd& socket_fd) const
+sdk::ErrorCode SocketAddress::connect(const OwnFd& socket_fd) const
 {
     const int raw_fd = socket_fd.get();
     CETL_DEBUG_ASSERT(raw_fd != -1, "");
 
-    const auto err = platform::posixSyscallError([this, raw_fd] {
+    const int err = platform::posixSyscallError([this, raw_fd] {
         //
         return ::connect(raw_fd, &asGenericAddr(), addr_len_);
     });
@@ -199,11 +200,11 @@ int SocketAddress::connect(const OwnFd& socket_fd) const
     {
     case 0:
     case EINPROGRESS: {
-        return 0;
+        return sdk::ErrorCode::Success;
     }
     default: {
         getLogger("io")->error("Failed to connect to server: {}.", std::strerror(err));
-        return err;
+        return static_cast<sdk::ErrorCode>(err);
     }
     }
 }
@@ -218,7 +219,7 @@ cetl::optional<OwnFd> SocketAddress::accept(const OwnFd& server_fd)
         OwnFd client_fd{::accept(server_fd.get(), &asGenericAddr(), &addr_len_)};
         if (client_fd.get() >= 0)
         {
-            if (const auto err = platform::posixSyscallError([&client_fd] {
+            if (const int err = platform::posixSyscallError([&client_fd] {
                     //
                     // NOLINTNEXTLINE(*-vararg)
                     return ::fcntl(client_fd.get(), F_SETFL, O_NONBLOCK);
@@ -287,17 +288,13 @@ cetl::optional<OwnFd> SocketAddress::accept(const OwnFd& server_fd)
 ///
 void SocketAddress::configureNoDelay(const OwnFd& fd)
 {
-    constexpr int enable = 1;
-    if (const auto err = platform::posixSyscallError([&fd, &enable] {
+    if (const int err = platform::posixSyscallError([&fd] {
             //
+            constexpr int enable = 1;
             return ::setsockopt(fd.get(), IPPROTO_TCP, TCP_NODELAY, &enable, sizeof(enable));
         }))
     {
-        getLogger("io")->warn("Failed to set TCP_NODELAY={} (fd={}, err={}): {}.",
-                              enable,
-                              fd.get(),
-                              err,
-                              std::strerror(err));
+        getLogger("io")->warn("Failed to set TCP_NODELAY=1 (fd={}, err={}): {}.", fd.get(), err, std::strerror(err));
     }
 }
 
@@ -319,7 +316,7 @@ SocketAddress::ParseResult::Var SocketAddress::parse(const std::string& conn_str
     }
 
     getLogger("io")->error("Unsupported connection string format (conn_str='{}').", conn_str);
-    return EINVAL;
+    return sdk::ErrorCode::InvalidArgument;
 }
 
 cetl::optional<SocketAddress::ParseResult::Var> SocketAddress::tryParseAsTcpAddress(const std::string&  conn_str,
@@ -339,7 +336,7 @@ cetl::optional<SocketAddress::ParseResult::Var> SocketAddress::tryParseAsTcpAddr
     const int     family = extractFamilyHostAndPort(addr_str, host, port);
     if (family == AF_UNSPEC)
     {
-        return EINVAL;
+        return sdk::ErrorCode::InvalidArgument;
     }
     if (auto result = tryParseAsWildcard(host, port))
     {
@@ -374,12 +371,12 @@ cetl::optional<SocketAddress::ParseResult::Var> SocketAddress::tryParseAsTcpAddr
     }
     case 0: {
         getLogger("io")->error("Unsupported ip address format (addr='{}').", host);
-        return EINVAL;
+        return sdk::ErrorCode::InvalidArgument;
     }
     default: {
         const int err = errno;
         getLogger("io")->error("Failed to parse address (addr='{}'): {}", host, std::strerror(err));
-        return err;
+        return static_cast<sdk::ErrorCode>(err);
     }
     }
 }
@@ -401,7 +398,7 @@ cetl::optional<SocketAddress::ParseResult::Var> SocketAddress::tryParseAsUnixDom
     if ((path.size() + 1) > sizeof(result_un.sun_path))
     {
         getLogger("io")->error("Unix domain path is too long (path='{}').", conn_str);
-        return EINVAL;
+        return sdk::ErrorCode::InvalidArgument;
     }
 
     // NOLINTNEXTLINE(*-array-to-pointer-decay, *-no-array-decay)
@@ -428,7 +425,7 @@ cetl::optional<SocketAddress::ParseResult::Var> SocketAddress::tryParseAsAbstrac
     if ((path.size() + 1) > (sizeof(result_un.sun_path) - 1))  // `-1` b/c path starts at `[1]` (see `memcpy` below).
     {
         getLogger("io")->error("Unix domain path is too long (path='{}').", conn_str);
-        return EINVAL;
+        return sdk::ErrorCode::InvalidArgument;
     }
 
     result_un.sun_path[0] = '\0';

--- a/src/common/io/socket_address.hpp
+++ b/src/common/io/socket_address.hpp
@@ -7,6 +7,7 @@
 #define OCVSMD_COMMON_NET_SOCKET_ADDRESS_HPP_INCLUDED
 
 #include "io.hpp"
+#include "ocvsmd/sdk/defines.hpp"
 
 #include <cetl/pf17/cetlpf.hpp>
 
@@ -29,7 +30,7 @@ class SocketAddress final
 public:
     struct ParseResult
     {
-        using Failure = int;  // aka errno
+        using Failure = sdk::ErrorCode;
         using Success = SocketAddress;
         using Var     = cetl::variant<Success, Failure>;
     };
@@ -55,14 +56,14 @@ public:
 
     struct SocketResult
     {
-        using Failure = int;  // aka errno
+        using Failure = sdk::ErrorCode;
         using Success = OwnFd;
         using Var     = cetl::variant<Success, Failure>;
     };
     SocketResult::Var socket(const int socket_type) const;
 
-    int                   bind(const OwnFd& socket_fd) const;
-    int                   connect(const OwnFd& socket_fd) const;
+    sdk::ErrorCode        bind(const OwnFd& socket_fd) const;
+    sdk::ErrorCode        connect(const OwnFd& socket_fd) const;
     cetl::optional<OwnFd> accept(const OwnFd& server_fd);
 
 private:

--- a/src/common/ipc/channel.hpp
+++ b/src/common/ipc/channel.hpp
@@ -17,7 +17,6 @@
 
 #include <spdlog/fmt/fmt.h>
 
-#include <cerrno>
 #include <cstddef>
 #include <cstdint>
 #include <functional>

--- a/src/common/ipc/client_router.cpp
+++ b/src/common/ipc/client_router.cpp
@@ -23,7 +23,6 @@
 #include <cetl/pf17/cetlpf.hpp>
 #include <cetl/visit_helpers.hpp>
 
-#include <cerrno>
 #include <cstdint>
 #include <memory>
 #include <unordered_map>

--- a/src/common/ipc/client_router.hpp
+++ b/src/common/ipc/client_router.hpp
@@ -8,6 +8,7 @@
 
 #include "channel.hpp"
 #include "gateway.hpp"
+#include "ocvsmd/sdk/defines.hpp"
 #include "pipe/client_pipe.hpp"
 
 #include <cetl/cetl.hpp>
@@ -39,7 +40,7 @@ public:
 
     virtual ~ClientRouter() = default;
 
-    CETL_NODISCARD virtual int                         start()  = 0;
+    CETL_NODISCARD virtual sdk::ErrorCode              start()  = 0;
     CETL_NODISCARD virtual cetl::pmr::memory_resource& memory() = 0;
 
     template <typename Ch>

--- a/src/common/ipc/gateway.hpp
+++ b/src/common/ipc/gateway.hpp
@@ -7,6 +7,7 @@
 #define OCVSMD_COMMON_IPC_GATEWAY_HPP_INCLUDED
 
 #include "ipc_types.hpp"
+#include "ocvsmd/sdk/defines.hpp"
 
 #include <cetl/cetl.hpp>
 #include <cetl/pf17/cetlpf.hpp>
@@ -57,15 +58,15 @@ public:
         };
         struct Completed final
         {
-            ErrorCode error_code;
-            bool      keep_alive;
+            sdk::ErrorCode error_code;
+            bool           keep_alive;
         };
 
         using Var = cetl::variant<Connected, Message, Completed>;
 
     };  // Event
 
-    using EventHandler = std::function<int(const Event::Var&)>;
+    using EventHandler = std::function<sdk::ErrorCode(const Event::Var&)>;
 
     // No copying or moving.
     Gateway(const Gateway&)                = delete;
@@ -73,10 +74,10 @@ public:
     Gateway& operator=(const Gateway&)     = delete;
     Gateway& operator=(Gateway&&) noexcept = delete;
 
-    CETL_NODISCARD virtual int send(const ServiceDesc::Id service_id, const Payload payload) = 0;
-    CETL_NODISCARD virtual int complete(const int error_code, const bool keep_alive)         = 0;
-    CETL_NODISCARD virtual int event(const Event::Var& event)                                = 0;
-    virtual void               subscribe(EventHandler event_handler)                         = 0;
+    CETL_NODISCARD virtual sdk::ErrorCode send(const ServiceDesc::Id service_id, const Payload payload)    = 0;
+    CETL_NODISCARD virtual sdk::ErrorCode complete(const sdk::ErrorCode error_code, const bool keep_alive) = 0;
+    CETL_NODISCARD virtual sdk::ErrorCode event(const Event::Var& event)                                   = 0;
+    virtual void                          subscribe(EventHandler event_handler)                            = 0;
 
 protected:
     Gateway()  = default;

--- a/src/common/ipc/ipc_types.hpp
+++ b/src/common/ipc/ipc_types.hpp
@@ -18,19 +18,6 @@ namespace common
 namespace ipc
 {
 
-/// Defines some common error codes of IPC operations.
-///
-/// Maps to `errno` values, hence `int` inheritance and zero on success.
-///
-enum class ErrorCode : int  // NOLINT
-{
-    Success      = 0,
-    NotConnected = ENOTCONN,
-    Disconnected = ECONNRESET,
-    Shutdown     = ESHUTDOWN,
-
-};  // ErrorCode
-
 using Payload  = cetl::span<const std::uint8_t>;
 using Payloads = cetl::span<const Payload>;
 

--- a/src/common/ipc/ipc_types.hpp
+++ b/src/common/ipc/ipc_types.hpp
@@ -8,7 +8,6 @@
 
 #include <cetl/pf20/cetlpf.hpp>
 
-#include <cerrno>
 #include <cstdint>
 
 namespace ocvsmd

--- a/src/common/ipc/pipe/client_pipe.hpp
+++ b/src/common/ipc/pipe/client_pipe.hpp
@@ -7,6 +7,7 @@
 #define OCVSMD_COMMON_IPC_PIPE_CLIENT_PIPE_HPP_INCLUDED
 
 #include "ipc/ipc_types.hpp"
+#include "ocvsmd/sdk/defines.hpp"
 
 #include <cetl/cetl.hpp>
 #include <cetl/pf17/cetlpf.hpp>
@@ -43,7 +44,7 @@ public:
 
     };  // Event
 
-    using EventHandler = std::function<int(const Event::Var&)>;
+    using EventHandler = std::function<sdk::ErrorCode(const Event::Var&)>;
 
     ClientPipe(const ClientPipe&)                = delete;
     ClientPipe(ClientPipe&&) noexcept            = delete;
@@ -52,8 +53,8 @@ public:
 
     virtual ~ClientPipe() = default;
 
-    CETL_NODISCARD virtual int start(EventHandler event_handler) = 0;
-    CETL_NODISCARD virtual int send(const Payloads payloads)     = 0;
+    CETL_NODISCARD virtual sdk::ErrorCode start(EventHandler event_handler) = 0;
+    CETL_NODISCARD virtual sdk::ErrorCode send(const Payloads payloads)     = 0;
 
 protected:
     ClientPipe() = default;

--- a/src/common/ipc/pipe/server_pipe.hpp
+++ b/src/common/ipc/pipe/server_pipe.hpp
@@ -6,8 +6,8 @@
 #ifndef OCVSMD_COMMON_IPC_PIPE_SERVER_PIPE_HPP_INCLUDED
 #define OCVSMD_COMMON_IPC_PIPE_SERVER_PIPE_HPP_INCLUDED
 
-#include "io/socket_address.hpp"
 #include "ipc/ipc_types.hpp"
+#include "ocvsmd/sdk/defines.hpp"
 
 #include <cetl/cetl.hpp>
 #include <cetl/pf17/cetlpf.hpp>
@@ -53,7 +53,7 @@ public:
 
     };  // Event
 
-    using EventHandler = std::function<int(const Event::Var&)>;
+    using EventHandler = std::function<sdk::ErrorCode(const Event::Var&)>;
 
     ServerPipe(const ServerPipe&)                = delete;
     ServerPipe(ServerPipe&&) noexcept            = delete;
@@ -62,8 +62,8 @@ public:
 
     virtual ~ServerPipe() = default;
 
-    CETL_NODISCARD virtual int start(EventHandler event_handler)                       = 0;
-    CETL_NODISCARD virtual int send(const ClientId client_id, const Payloads payloads) = 0;
+    CETL_NODISCARD virtual sdk::ErrorCode start(EventHandler event_handler)                       = 0;
+    CETL_NODISCARD virtual sdk::ErrorCode send(const ClientId client_id, const Payloads payloads) = 0;
 
 protected:
     ServerPipe() = default;

--- a/src/common/ipc/pipe/socket_base.hpp
+++ b/src/common/ipc/pipe/socket_base.hpp
@@ -9,6 +9,7 @@
 #include "io/io.hpp"
 #include "ipc/ipc_types.hpp"
 #include "logging.hpp"
+#include "ocvsmd/sdk/defines.hpp"
 
 #include <cetl/cetl.hpp>
 #include <cetl/pf17/cetlpf.hpp>
@@ -45,10 +46,10 @@ public:
         };
         using MsgPart = cetl::variant<MsgHeader, MsgPayload>;
 
-        io::OwnFd                   fd;
-        std::size_t                 rx_partial_size{0};
-        MsgPart                     rx_msg_part{MsgHeader{}};
-        std::function<int(Payload)> on_rx_msg_payload;
+        io::OwnFd                              fd;
+        std::size_t                            rx_partial_size{0};
+        MsgPart                                rx_msg_part{MsgHeader{}};
+        std::function<sdk::ErrorCode(Payload)> on_rx_msg_payload;
 
     };  // IoState
 
@@ -66,8 +67,8 @@ protected:
         return *logger_;
     }
 
-    CETL_NODISCARD int send(const IoState& io_state, const Payloads payloads) const;
-    CETL_NODISCARD int receiveData(IoState& io_state) const;
+    CETL_NODISCARD sdk::ErrorCode send(const IoState& io_state, const Payloads payloads) const;
+    CETL_NODISCARD sdk::ErrorCode receiveData(IoState& io_state) const;
 
 private:
     LoggerPtr logger_{getLogger("ipc")};

--- a/src/common/ipc/pipe/socket_base.hpp
+++ b/src/common/ipc/pipe/socket_base.hpp
@@ -14,7 +14,6 @@
 #include <cetl/cetl.hpp>
 #include <cetl/pf17/cetlpf.hpp>
 
-#include <cerrno>
 #include <cstddef>
 #include <cstdint>
 #include <functional>

--- a/src/common/ipc/pipe/socket_client.cpp
+++ b/src/common/ipc/pipe/socket_client.cpp
@@ -8,6 +8,7 @@
 #include "ipc/ipc_types.hpp"
 #include "ocvsmd/platform/posix_executor_extension.hpp"
 #include "ocvsmd/platform/posix_utils.hpp"
+#include "ocvsmd/sdk/defines.hpp"
 #include "socket_base.hpp"
 
 #include <cetl/cetl.hpp>
@@ -42,17 +43,18 @@ SocketClient::SocketClient(libcyphal::IExecutor& executor, const io::SocketAddre
     };
 }
 
-int SocketClient::start(EventHandler event_handler)
+sdk::ErrorCode SocketClient::start(EventHandler event_handler)
 {
     CETL_DEBUG_ASSERT(event_handler, "");
     CETL_DEBUG_ASSERT(io_state_.fd.get() == -1, "");
 
     event_handler_ = std::move(event_handler);
 
-    if (const auto err = makeSocketHandle())
+    const auto error_code = makeSocketHandle();
+    if (error_code != sdk::ErrorCode::Success)
     {
-        logger().error("Failed to make client socket handle: {}.", std::strerror(err));
-        return err;
+        logger().error("Failed to make client socket handle (err={}).", error_code);
+        return error_code;
     }
 
     socket_callback_ = posix_executor_ext_->registerAwaitableCallback(  //
@@ -62,43 +64,41 @@ int SocketClient::start(EventHandler event_handler)
         },
         platform::IPosixExecutorExtension::Trigger::Writable{io_state_.fd.get()});
 
-    return 0;
+    return sdk::ErrorCode::Success;
 }
 
-int SocketClient::makeSocketHandle()
+sdk::ErrorCode SocketClient::makeSocketHandle()
 {
     using SocketResult = io::SocketAddress::SocketResult;
 
     auto maybe_socket = socket_address_.socket(SOCK_STREAM);
-    if (const auto* const err = cetl::get_if<SocketResult::Failure>(&maybe_socket))
+    if (const auto* const failure = cetl::get_if<SocketResult::Failure>(&maybe_socket))
     {
-        logger().error("Failed to create client socket (err={}): {}.", *err, std::strerror(*err));
-        return *err;
+        logger().error("Failed to create client socket (err={}).", *failure);
+        return *failure;
     }
     auto socket_fd = cetl::get<SocketResult::Success>(std::move(maybe_socket));
     CETL_DEBUG_ASSERT(socket_fd.get() != -1, "");
 
-    if (const int err = socket_address_.connect(socket_fd))
+    const sdk::ErrorCode error_code = socket_address_.connect(socket_fd);
+    if ((error_code != sdk::ErrorCode::Success) && (error_code != sdk::ErrorCode::OperationInProgress))
     {
-        if (err != EINPROGRESS)
-        {
-            logger().error("Failed to connect to server (err={}): {}.", err, std::strerror(err));
-            return err;
-        }
+        logger().error("Failed to connect to server (err={}).", error_code);
+        return error_code;
     }
 
     io_state_.fd = std::move(socket_fd);
-    return 0;
+    return sdk::ErrorCode::Success;
 }
 
-int SocketClient::send(const Payloads payloads)
+sdk::ErrorCode SocketClient::send(const Payloads payloads)
 {
     return SocketBase::send(io_state_, payloads);
 }
 
-int SocketClient::connectSocket(const int fd, const void* const addr_ptr, const std::size_t addr_size) const
+sdk::ErrorCode SocketClient::connectSocket(const int fd, const void* const addr_ptr, const std::size_t addr_size) const
 {
-    if (const auto err = platform::posixSyscallError([fd, addr_ptr, addr_size] {
+    if (const int err = platform::posixSyscallError([fd, addr_ptr, addr_size] {
             //
             return ::connect(fd, static_cast<const sockaddr*>(addr_ptr), addr_size);
         }))
@@ -106,10 +106,10 @@ int SocketClient::connectSocket(const int fd, const void* const addr_ptr, const 
         if (err != EINPROGRESS)
         {
             logger().error("Failed to connect to server: {}.", std::strerror(err));
-            return err;
+            return static_cast<sdk::ErrorCode>(err);
         }
     }
-    return 0;
+    return sdk::ErrorCode::Success;
 }
 
 void SocketClient::handle_connect()
@@ -117,7 +117,7 @@ void SocketClient::handle_connect()
     socket_callback_.reset();
 
     int so_error = 0;
-    if (const auto err = platform::posixSyscallError([this, &so_error] {
+    if (const int err = platform::posixSyscallError([this, &so_error] {
             //
             socklen_t len = sizeof(so_error);
             return ::getsockopt(io_state_.fd.get(), SOL_SOCKET, SO_ERROR, &so_error, &len);
@@ -145,17 +145,16 @@ void SocketClient::handle_connect()
 
 void SocketClient::handle_receive()
 {
-    if (const auto err = receiveData(io_state_))
+    const auto error_code = receiveData(io_state_);
+    if (error_code != sdk::ErrorCode::Success)
     {
-        if (err == -1)
+        if (error_code == sdk::ErrorCode::Disconnected)
         {
             logger().debug("End of server stream - closing connection.");
         }
         else
         {
-            logger().warn("Failed to handle server response - closing connection (err={}): {}.",
-                          err,
-                          std::strerror(err));
+            logger().warn("Failed to handle server response - closing connection (err={}).", error_code);
         }
 
         handle_disconnect();

--- a/src/common/ipc/pipe/socket_client.hpp
+++ b/src/common/ipc/pipe/socket_client.hpp
@@ -10,6 +10,7 @@
 #include "io/socket_address.hpp"
 #include "ipc/ipc_types.hpp"
 #include "ocvsmd/platform/posix_executor_extension.hpp"
+#include "ocvsmd/sdk/defines.hpp"
 #include "socket_base.hpp"
 
 #include <cetl/cetl.hpp>
@@ -39,16 +40,16 @@ public:
     ~SocketClient() override = default;
 
 private:
-    int  makeSocketHandle();
-    int  connectSocket(const int fd, const void* const addr_ptr, const std::size_t addr_size) const;
-    void handle_connect();
-    void handle_receive();
-    void handle_disconnect();
+    sdk::ErrorCode makeSocketHandle();
+    sdk::ErrorCode connectSocket(const int fd, const void* const addr_ptr, const std::size_t addr_size) const;
+    void           handle_connect();
+    void           handle_receive();
+    void           handle_disconnect();
 
     // ClientPipe
     //
-    CETL_NODISCARD int start(EventHandler event_handler) override;
-    CETL_NODISCARD int send(const Payloads payloads) override;
+    CETL_NODISCARD sdk::ErrorCode start(EventHandler event_handler) override;
+    CETL_NODISCARD sdk::ErrorCode send(const Payloads payloads) override;
 
     io::SocketAddress                        socket_address_;
     platform::IPosixExecutorExtension* const posix_executor_ext_;

--- a/src/common/ipc/pipe/socket_server.cpp
+++ b/src/common/ipc/pipe/socket_server.cpp
@@ -19,7 +19,6 @@
 #include <cetl/rtti.hpp>
 #include <libcyphal/executor.hpp>
 
-#include <cerrno>
 #include <cstring>
 #include <memory>
 #include <sys/socket.h>

--- a/src/common/ipc/pipe/socket_server.hpp
+++ b/src/common/ipc/pipe/socket_server.hpp
@@ -8,8 +8,10 @@
 
 #include "client_context.hpp"
 #include "io/io.hpp"
+#include "io/socket_address.hpp"
 #include "ipc/ipc_types.hpp"
 #include "ocvsmd/platform/posix_executor_extension.hpp"
+#include "ocvsmd/sdk/defines.hpp"
 #include "server_pipe.hpp"
 #include "socket_base.hpp"
 
@@ -41,15 +43,15 @@ public:
     ~SocketServer() override = default;
 
 private:
-    int            makeSocketHandle();
+    sdk::ErrorCode makeSocketHandle();
     void           handleAccept();
     void           handleClientRequest(const ClientId client_id);
     ClientContext* tryFindClientContext(const ClientId client_id);
 
     // ServerPipe
     //
-    CETL_NODISCARD int start(EventHandler event_handler) override;
-    CETL_NODISCARD int send(const ClientId client_id, const Payloads payloads) override;
+    CETL_NODISCARD sdk::ErrorCode start(EventHandler event_handler) override;
+    CETL_NODISCARD sdk::ErrorCode send(const ClientId client_id, const Payloads payloads) override;
 
     io::OwnFd                                        server_fd_;
     io::SocketAddress                                socket_address_;

--- a/src/common/ipc/server_router.cpp
+++ b/src/common/ipc/server_router.cpp
@@ -22,7 +22,6 @@
 #include <cetl/pf17/cetlpf.hpp>
 #include <cetl/visit_helpers.hpp>
 
-#include <cerrno>
 #include <cstdint>
 #include <memory>
 #include <unordered_map>

--- a/src/common/ipc/server_router.hpp
+++ b/src/common/ipc/server_router.hpp
@@ -9,6 +9,7 @@
 #include "channel.hpp"
 #include "gateway.hpp"
 #include "ipc_types.hpp"
+#include "ocvsmd/sdk/defines.hpp"
 #include "pipe/server_pipe.hpp"
 
 #include <cetl/cetl.hpp>
@@ -41,7 +42,7 @@ public:
 
     virtual ~ServerRouter() = default;
 
-    CETL_NODISCARD virtual int                         start()  = 0;
+    CETL_NODISCARD virtual sdk::ErrorCode              start()  = 0;
     CETL_NODISCARD virtual cetl::pmr::memory_resource& memory() = 0;
 
     template <typename Ch>

--- a/src/common/svc/node/exec_cmd_spec.hpp
+++ b/src/common/svc/node/exec_cmd_spec.hpp
@@ -6,7 +6,7 @@
 #ifndef OCVSMD_COMMON_SVC_NODE_EXEC_CMD_SPEC_HPP_INCLUDED
 #define OCVSMD_COMMON_SVC_NODE_EXEC_CMD_SPEC_HPP_INCLUDED
 
-#include "ocvsmd/common/svc/node/ExecCmd_0_1.hpp"
+#include "ocvsmd/common/svc/node/ExecCmd_0_2.hpp"
 
 namespace ocvsmd
 {
@@ -19,8 +19,8 @@ namespace node
 
 struct ExecCmdSpec
 {
-    using Request  = ExecCmd::Request_0_1;
-    using Response = ExecCmd::Response_0_1;
+    using Request  = ExecCmd::Request_0_2;
+    using Response = ExecCmd::Response_0_2;
 
     constexpr auto static svc_full_name()
     {

--- a/src/daemon/engine/cyphal/file_provider.cpp
+++ b/src/daemon/engine/cyphal/file_provider.cpp
@@ -177,8 +177,8 @@ private:
         auto maybe_server = presentation.makeServer<Service>();
         if (const auto* const failure = cetl::get_if<Presentation::MakeFailure>(&maybe_server))
         {
-            const auto err = failureToErrorCode(*failure);
-            spdlog::error("Failed to make '{}' server (err={}).", role, err);
+            const auto error_code = failureToErrorCode(*failure);
+            spdlog::error("Failed to make '{}' server (err={}).", role, error_code);
             return cetl::nullopt;
         }
         return cetl::get<typename Service::Server>(std::move(maybe_server));

--- a/src/daemon/engine/engine.cpp
+++ b/src/daemon/engine/engine.cpp
@@ -146,7 +146,7 @@ cetl::optional<std::string> Engine::init()
     svc::node::registerAllServices(svc_context);
     svc::file_server::registerAllServices(svc_context, *file_provider_);
     //
-    if (0 != ipc_router_->start())
+    if (sdk::ErrorCode::Success != ipc_router_->start())
     {
         std::string msg = "Failed to start IPC router.";
         logger_->error(msg);

--- a/src/daemon/engine/engine_helpers.hpp
+++ b/src/daemon/engine/engine_helpers.hpp
@@ -6,6 +6,8 @@
 #ifndef OCVSMD_DAEMON_ENGINE_HELPERS_HPP_INCLUDED
 #define OCVSMD_DAEMON_ENGINE_HELPERS_HPP_INCLUDED
 
+#include "ocvsmd/sdk/defines.hpp"
+
 #include <nunavut/support/serialization.hpp>
 
 #include <cetl/pf17/cetlpf.hpp>
@@ -14,8 +16,6 @@
 #include <libcyphal/presentation/response_promise.hpp>
 #include <libcyphal/transport/errors.hpp>
 
-#include <cerrno>
-
 namespace ocvsmd
 {
 namespace daemon
@@ -23,50 +23,51 @@ namespace daemon
 namespace engine
 {
 
-inline int errorToCode(const libcyphal::MemoryError) noexcept
+inline sdk::ErrorCode errorToCode(const libcyphal::MemoryError) noexcept
 {
-    return ENOMEM;
+    return sdk::ErrorCode::OutOfMemory;
 }
-inline int errorToCode(const libcyphal::transport::CapacityError) noexcept
+inline sdk::ErrorCode errorToCode(const libcyphal::transport::CapacityError) noexcept
 {
-    return ENOMEM;
-}
-
-inline int errorToCode(const libcyphal::ArgumentError) noexcept
-{
-    return EINVAL;
-}
-inline int errorToCode(const libcyphal::transport::AnonymousError) noexcept
-{
-    return EINVAL;
-}
-inline int errorToCode(const nunavut::support::Error) noexcept
-{
-    return EINVAL;
+    return sdk::ErrorCode::OutOfMemory;
 }
 
-inline int errorToCode(const libcyphal::transport::AlreadyExistsError) noexcept
+inline sdk::ErrorCode errorToCode(const libcyphal::ArgumentError) noexcept
 {
-    return EEXIST;
+    return sdk::ErrorCode::InvalidArgument;
+}
+inline sdk::ErrorCode errorToCode(const libcyphal::transport::AnonymousError) noexcept
+{
+    return sdk::ErrorCode::InvalidArgument;
+}
+inline sdk::ErrorCode errorToCode(const nunavut::support::Error) noexcept
+{
+    return sdk::ErrorCode::InvalidArgument;
 }
 
-inline int errorToCode(const libcyphal::transport::PlatformError& platform_error) noexcept
+inline sdk::ErrorCode errorToCode(const libcyphal::transport::AlreadyExistsError) noexcept
 {
-    return static_cast<int>(platform_error->code());
+    return sdk::ErrorCode::AlreadyExists;
 }
 
-inline int errorToCode(const libcyphal::presentation::ResponsePromiseExpired) noexcept
+inline sdk::ErrorCode errorToCode(const libcyphal::transport::PlatformError& platform_error) noexcept
 {
-    return ETIMEDOUT;
+    return static_cast<sdk::ErrorCode>(platform_error->code());
 }
 
-inline int errorToCode(const libcyphal::presentation::detail::ClientBase::TooManyPendingRequestsError) noexcept
+inline sdk::ErrorCode errorToCode(const libcyphal::presentation::ResponsePromiseExpired) noexcept
 {
-    return EBUSY;
+    return sdk::ErrorCode::TimedOut;
+}
+
+inline sdk::ErrorCode errorToCode(
+    const libcyphal::presentation::detail::ClientBase::TooManyPendingRequestsError) noexcept
+{
+    return sdk::ErrorCode::Busy;
 }
 
 template <typename Variant>
-int failureToErrorCode(const Variant& failure)
+sdk::ErrorCode failureToErrorCode(const Variant& failure)
 {
     return cetl::visit([](const auto& error) { return errorToCode(error); }, failure);
 }

--- a/src/daemon/engine/platform/can/can_media.hpp
+++ b/src/daemon/engine/platform/can/can_media.hpp
@@ -23,7 +23,6 @@
 
 #include <algorithm>
 #include <array>
-#include <cerrno>
 #include <cstddef>
 #include <cstdint>
 #include <iterator>

--- a/src/daemon/engine/svc/file_server/list_roots_service.cpp
+++ b/src/daemon/engine/svc/file_server/list_roots_service.cpp
@@ -73,15 +73,17 @@ public:
 
             ipc_response.item.path.clear();
             std::copy(root.cbegin(), root.cend(), std::back_inserter(ipc_response.item.path));
-            if (const auto err = channel.send(ipc_response))
+            const auto error_code = channel.send(ipc_response);
+            if (error_code != sdk::ErrorCode::Success)
             {
-                logger_->warn("ListRootsSvc: failed to send ipc response (err={}).", err);
+                logger_->warn("ListRootsSvc: failed to send ipc response (err={}).", error_code);
             }
         }
 
-        if (const auto err = channel.complete())
+        const auto error_code = channel.complete();
+        if (error_code != sdk::ErrorCode::Success)
         {
-            logger_->warn("ListRootsSvc: failed to send ipc completion (err={}).", err);
+            logger_->warn("ListRootsSvc: failed to send ipc completion (err={}).", error_code);
         }
     }
 

--- a/src/daemon/engine/svc/file_server/pop_root_service.cpp
+++ b/src/daemon/engine/svc/file_server/pop_root_service.cpp
@@ -61,9 +61,10 @@ public:
         std::copy(request.item.path.cbegin(), request.item.path.cend(), std::back_inserter(path));
         file_provider_.popRoot(path, request.is_back);
 
-        if (const auto err = channel.complete())
+        const auto error_code = channel.complete();
+        if (error_code != sdk::ErrorCode::Success)
         {
-            logger_->warn("PopRootSvc: failed to send ipc completion (err={}).", err);
+            logger_->warn("PopRootSvc: failed to send ipc completion (err={}).", error_code);
         }
     }
 

--- a/src/daemon/engine/svc/file_server/push_root_service.cpp
+++ b/src/daemon/engine/svc/file_server/push_root_service.cpp
@@ -61,9 +61,10 @@ public:
         std::copy(request.item.path.cbegin(), request.item.path.cend(), std::back_inserter(path));
         file_provider_.pushRoot(path, request.is_back);
 
-        if (const auto err = channel.complete())
+        const auto error_code = channel.complete();
+        if (error_code != sdk::ErrorCode::Success)
         {
-            logger_->warn("PushRootSvc: failed to send ipc completion (err={}).", err);
+            logger_->warn("PushRootSvc: failed to send ipc completion (err={}).", error_code);
         }
     }
 

--- a/src/daemon/engine/svc/node/access_registers_service.cpp
+++ b/src/daemon/engine/svc/node/access_registers_service.cpp
@@ -226,6 +226,8 @@ private:
         {
             using CyMakeFailure = libcyphal::presentation::Presentation::MakeFailure;
 
+            CETL_DEBUG_ASSERT(processing_, "");
+
             const auto it = node_id_to_cnxt_.find(node_id);
             if (it == node_id_to_cnxt_.end())
             {

--- a/src/daemon/engine/svc/node/access_registers_service.cpp
+++ b/src/daemon/engine/svc/node/access_registers_service.cpp
@@ -20,7 +20,6 @@
 #include <libcyphal/presentation/presentation.hpp>
 #include <libcyphal/presentation/response_promise.hpp>
 
-#include <cerrno>
 #include <chrono>
 #include <cstdint>
 #include <memory>

--- a/src/daemon/engine/svc/node/access_registers_service.cpp
+++ b/src/daemon/engine/svc/node/access_registers_service.cpp
@@ -103,10 +103,7 @@ private:
             });
         }
 
-        ~Fsm()
-        {
-            logger().trace("AccessRegsSvc::~Fsm (id={}).", id_);
-        }
+        ~Fsm() = default;
 
         Fsm(const Fsm&)                = delete;
         Fsm(Fsm&&) noexcept            = delete;
@@ -120,7 +117,6 @@ private:
 
     private:
         using RegKeyValue = common::svc::node::AccessRegistersKeyValue_0_1;
-        using RegKey      = RegKeyValue::_traits_::TypeOf::key;
         using RegValue    = RegKeyValue::_traits_::TypeOf::value;
 
         using CyRegAccessSvc   = uavcan::_register::Access_1_0;

--- a/src/daemon/engine/svc/node/access_registers_service.cpp
+++ b/src/daemon/engine/svc/node/access_registers_service.cpp
@@ -149,7 +149,7 @@ private:
             CETL_DEBUG_ASSERT(!processing_, "");
             if (processing_)
             {
-                logger().warn("AccessRegsSvc: Ignoring extra input - already processing (id={}).", id_);
+                logger().warn("AccessRegsSvc: Ignoring extra input - already processing (fsm_id={}).", id_);
                 return;
             }
 
@@ -176,25 +176,26 @@ private:
 
         void handleEvent(const Channel::Completed& completed)
         {
-            logger().debug("AccessRegsSvc::Fsm::handleEvent({}) (id={}).", completed, id_);
+            logger().debug("AccessRegsSvc::handleEvent({}) (fsm_id={}).", completed, id_);
 
             if (!completed.keep_alive)
             {
-                logger().warn("AccessRegsSvc: canceling processing (id={}).", id_);
+                logger().warn("AccessRegsSvc: canceling processing (fsm_id={}).", id_);
                 complete(sdk::ErrorCode::Canceled);
                 return;
             }
 
             if (processing_)
             {
-                logger().warn("AccessRegsSvc: Ignoring extra channel completion - already processing (id={}).", id_);
+                logger().warn("AccessRegsSvc: Ignoring extra channel completion - already processing (fsm_id={}).",
+                              id_);
                 return;
             }
             processing_ = true;
 
             if (node_id_to_cnxt_.empty() || registers_.empty())
             {
-                logger().debug("AccessRegsSvc: Nothing to do - empty working set (id={}, nodes={}, regs={}).",
+                logger().debug("AccessRegsSvc: Nothing to do - empty working set (fsm_id={}, nodes={}, regs={}).",
                                id_,
                                node_id_to_cnxt_.size(),
                                registers_.size());
@@ -334,12 +335,12 @@ private:
             ipc_response.node_id    = node_id;
             ipc_response._register  = reg;
 
-            const auto send_error_code = channel_.send(ipc_response);
-            if (send_error_code != sdk::ErrorCode::Success)
+            const auto failure = channel_.send(ipc_response);
+            if (failure != sdk::ErrorCode::Success)
             {
                 logger().warn("AccessRegsSvc: failed to send ipc response for node {} (err={}, fsm_id={}).",
                               node_id,
-                              send_error_code,
+                              failure,
                               id_);
             }
         }

--- a/src/daemon/engine/svc/node/exec_cmd_service.cpp
+++ b/src/daemon/engine/svc/node/exec_cmd_service.cpp
@@ -20,7 +20,6 @@
 #include <libcyphal/presentation/presentation.hpp>
 #include <libcyphal/presentation/response_promise.hpp>
 
-#include <cerrno>
 #include <cstdint>
 #include <memory>
 #include <unordered_map>

--- a/src/daemon/engine/svc/node/exec_cmd_service.cpp
+++ b/src/daemon/engine/svc/node/exec_cmd_service.cpp
@@ -26,6 +26,7 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
+#include <vector>
 
 namespace ocvsmd
 {
@@ -91,6 +92,7 @@ private:
             : id_{id}
             , channel_{std::move(channel)}
             , service_{service}
+            , processing_{false}
         {
             logger().trace("ExecCmdSvc::Fsm (id={}).", id_);
 
@@ -100,10 +102,7 @@ private:
             });
         }
 
-        ~Fsm()
-        {
-            logger().trace("ExecCmdSvc::~Fsm (id={}).", id_);
-        }
+        ~Fsm() = default;
 
         Fsm(const Fsm&)                = delete;
         Fsm(Fsm&&) noexcept            = delete;
@@ -112,44 +111,24 @@ private:
 
         void start(const Spec::Request& request)
         {
-            logger().trace("ExecCmdSvc::Fsm::start (fsm_id={}, timeout={}us).", id_, request.timeout_us);
-
-            // Immediately complete if there are no nodes to execute the command on.
-            //
-            if (request.node_ids.empty())
-            {
-                complete(0);
-                return;
-            }
-
-            // It's ok to have duplicates in the request -
-            // we just ignore duplicates, and work with unique ones.
-            const SetOfNodeIds unique_node_ids{request.node_ids.begin(), request.node_ids.end()};
-
-            const auto deadline = service_.context_.executor.now() + std::chrono::microseconds{request.timeout_us};
-            const CyExecCmdSvc::Request cy_request{request.payload.command, request.payload.parameter, &memory()};
-            for (const auto node_id : unique_node_ids)
-            {
-                if (const auto err = makeCySvcCallFor(deadline, node_id, cy_request))
-                {
-                    complete(err);
-                    return;
-                }
-            }
+            handleEvent(request);
         }
 
     private:
-        using SetOfNodeIds = std::unordered_set<sdk::CyphalNodeId>;
+        using RequestPayload  = common::svc::node::UavcanNodeExecCmdReq_0_1;
+        using ResponsePayload = common::svc::node::UavcanNodeExecCmdRes_0_1;
 
         using CyExecCmdSvc     = uavcan::node::ExecuteCommand_1_3;
         using CySvcClient      = libcyphal::presentation::ServiceClient<CyExecCmdSvc>;
         using CyPromise        = libcyphal::presentation::ResponsePromise<CyExecCmdSvc::Response>;
         using CyPromiseFailure = libcyphal::presentation::ResponsePromiseFailure;
 
-        struct CyNodeOp
+        struct NodeContext
         {
-            CySvcClient client;
-            CyPromise   promise;
+            libcyphal::Duration         timeout;
+            RequestPayload              payload;
+            cetl::optional<CySvcClient> client;
+            cetl::optional<CyPromise>   promise;
         };
 
         common::Logger& logger() const
@@ -162,92 +141,198 @@ private:
             return service_.context_.memory;
         }
 
-        // We are not interested in handling these events.
+        // We are not interested in handling this events.
         static void handleEvent(const Channel::Connected&) {}
-        static void handleEvent(const Channel::Input&) {}
+
+        void handleEvent(const Channel::Input& input)
+        {
+            CETL_DEBUG_ASSERT(!processing_, "");
+            if (processing_)
+            {
+                logger().warn("ExecCmdSvc: Ignoring extra input - already processing (id={}).", id_);
+                return;
+            }
+
+            const auto timeout = std::chrono::duration_cast<libcyphal::Duration>(  //
+                std::chrono::microseconds{input.timeout_us});
+
+            for (const auto node_id : input.node_ids)
+            {
+                node_id_to_cnxt_.emplace(node_id, NodeContext{timeout, input.payload});
+            }
+        }
 
         void handleEvent(const Channel::Completed& completed)
         {
-            logger().debug("ExecCmdSvc::Fsm::handleEvent({}) (id={}).", completed, id_);
-            complete(ECANCELED);
+            logger().debug("ExecCmdSvc::handleEvent({}) (id={}).", completed, id_);
+
+            if (!completed.keep_alive)
+            {
+                logger().warn("ExecCmdSvc: canceling processing (id={}).", id_);
+                complete(ECANCELED);
+                return;
+            }
+
+            if (processing_)
+            {
+                logger().warn("ExecCmdSvc: Ignoring extra channel completion - already processing (id={}).", id_);
+                return;
+            }
+            processing_ = true;
+
+            if (node_id_to_cnxt_.empty())
+            {
+                logger().debug("ExecCmdSvc: Nothing to do - empty working set (id={}, nodes={}).",
+                               id_,
+                               node_id_to_cnxt_.size());
+                complete(0);
+                return;
+            }
+
+            // Below `makeCyRpcClient` call might modify `node_id_to_cnxt_`,
+            // so we need to collect all node ids first.
+            //
+            std::vector<sdk::CyphalNodeId> node_ids;
+            node_ids.reserve(node_id_to_cnxt_.size());
+            for (const auto& pair : node_id_to_cnxt_)
+            {
+                node_ids.push_back(pair.first);
+            }
+
+            // For each node we try initiate execute command RPC call.
+            //
+            for (const auto node_id : node_ids)
+            {
+                makeCyRpcClient(node_id);
+            }
         }
 
-        int makeCySvcCallFor(const libcyphal::TimePoint   deadline,
-                             const sdk::CyphalNodeId      node_id,
-                             const CyExecCmdSvc::Request& cy_request)
+        void makeCyRpcClient(const sdk::CyphalNodeId node_id)
         {
             using CyMakeFailure = libcyphal::presentation::Presentation::MakeFailure;
+
+            const auto it = node_id_to_cnxt_.find(node_id);
+            if (it == node_id_to_cnxt_.end())
+            {
+                return;
+            }
+            auto& node_cnxt = it->second;
 
             auto cy_make_result = service_.context_.presentation.makeClient<CyExecCmdSvc>(node_id);
             if (const auto* cy_failure = cetl::get_if<CyMakeFailure>(&cy_make_result))
             {
                 const auto err = failureToErrorCode(*cy_failure);
-                logger().error("ExecCmdSvc: failed to make RPC client for node {} (err={}, fsm_id={}).",
-                               node_id,
-                               err,
-                               id_);
-                return err;
-            }
-            auto cy_svc_client = cetl::get<CySvcClient>(std::move(cy_make_result));
+                logger().warn("ExecCmdSvc: failed to make RPC client for node {} (err={}, fsm_id={}).",
+                              node_id,
+                              err,
+                              id_);
 
-            auto cy_req_result = cy_svc_client.request(deadline, cy_request);
-            if (const auto* cy_failure = cetl::get_if<CySvcClient::Failure>(&cy_req_result))
+                sendResponse(node_id, ResponsePayload{&memory()}, err);
+                releaseNodeContext(node_id);
+                return;
+            }
+            node_cnxt.client.emplace(cetl::get<CySvcClient>(std::move(cy_make_result)));
+
+            startCyExecCmdRpcCallFor(node_id, node_cnxt);
+        }
+
+        void startCyExecCmdRpcCallFor(const sdk::CyphalNodeId node_id, NodeContext& node_cnxt)
+        {
+            CETL_DEBUG_ASSERT(processing_, "");
+            CETL_DEBUG_ASSERT(node_cnxt.client, "");
+
+            const auto                  deadline = service_.context_.executor.now() + node_cnxt.timeout;
+            const CyExecCmdSvc::Request cy_request{node_cnxt.payload.command, node_cnxt.payload.parameter, &memory()};
+
+            auto cy_req_result = node_cnxt.client->request(deadline, cy_request);
+            if (auto* const cy_failure = cetl::get_if<CySvcClient::Failure>(&cy_req_result))
             {
                 const auto err = failureToErrorCode(*cy_failure);
-                logger().error("ExecCmdSvc: failed to send RPC request to node {} (err={}, fsm_id={})",
-                               node_id,
-                               err,
-                               id_);
-                return err;
-            }
-            auto cy_promise = cetl::get<CyPromise>(std::move(cy_req_result));
+                logger().warn("ExecCmdSvc: failed to send RPC request to node {} (err={}, fsm_id={})",
+                              node_id,
+                              err,
+                              id_);
 
+                sendResponse(node_id, ResponsePayload{&memory()}, err);
+                releaseNodeContext(node_id);
+                return;
+            }
+
+            auto cy_promise = cetl::get<CyPromise>(std::move(cy_req_result));
             cy_promise.setCallback([this, node_id](const auto& arg) {
                 //
-                if (const auto* cy_failure = cetl::get_if<CyPromiseFailure>(&arg.result))
-                {
-                    const auto err = failureToErrorCode(*cy_failure);
-                    logger().warn("ExecCmdSvc: RPC promise failure for node {} (err={}, fsm_id={}).",
-                                  node_id,
-                                  err,
-                                  id_);
-                }
-                else if (const auto* success = cetl::get_if<CyPromise::Success>(&arg.result))
-                {
-                    const auto& res = success->response;
-                    logger().debug("ExecCmdSvc: RPC promise success from node {} (status={}, fsm_id={}).",
-                                   node_id,
-                                   res.status,
-                                   id_);
-
-                    const Spec::Response ipc_response{node_id, {res.status, res.output, &memory()}, &memory()};
-                    if (const auto err = channel_.send(ipc_response))
-                    {
-                        logger().warn("ExecCmdSvc: failed to send ipc response for node {} (err={}, fsm_id={}).",
-                                      node_id,
-                                      err,
-                                      id_);
-                    }
-                }
-
-                // We've got the response from the node, so we can release associated resources (client & promise).
-                // If no nodes left, then it means we did it for all nodes, so the whole FSM is completed.
-                //
-                node_id_to_op_.erase(node_id);
-                if (node_id_to_op_.empty())
-                {
-                    complete(0);
-                }
+                handleNodeResponse(node_id, arg.result);
             });
+            node_cnxt.promise.emplace(std::move(cy_promise));
+        }
 
-            node_id_to_op_.emplace(node_id, CyNodeOp{std::move(cy_svc_client), std::move(cy_promise)});
-            return 0;
+        void handleNodeResponse(const sdk::CyphalNodeId node_id, const CyPromise::Result& result)
+        {
+            const auto it = node_id_to_cnxt_.find(node_id);
+            if (it == node_id_to_cnxt_.end())
+            {
+                return;
+            }
+            auto& node_cnxt = it->second;
+
+            CETL_DEBUG_ASSERT(processing_, "");
+
+            int             err_code = 0;
+            ResponsePayload payload{&memory()};
+            //
+            if (const auto* success = cetl::get_if<CyPromise::Success>(&result))
+            {
+                const auto& res = success->response;
+                logger().debug("ExecCmdSvc: RPC promise success from node {} (status={}, fsm_id={}).",
+                               node_id,
+                               res.status,
+                               id_);
+
+                payload.status = res.status;
+                payload.output = res.output;
+            }
+            else if (const auto* cy_failure = cetl::get_if<CyPromiseFailure>(&result))
+            {
+                err_code = failureToErrorCode(*cy_failure);
+                logger().warn("ExecCmdSvc: RPC promise failure for node {} (err={}, fsm_id={}).",
+                              node_id,
+                              err_code,
+                              id_);
+            }
+            sendResponse(node_id, payload, err_code);
+
+            releaseNodeContext(node_id);
+        }
+
+        void sendResponse(const sdk::CyphalNodeId node_id, const ResponsePayload& payload, const int err_code = 0)
+        {
+            Spec::Response ipc_response{&memory()};
+            ipc_response.error_code = err_code;
+            ipc_response.node_id    = node_id;
+            ipc_response.payload    = payload;
+
+            if (const auto err = channel_.send(ipc_response))
+            {
+                logger().warn("ExecCmdSvc: failed to send ipc response for node {} (err={}, fsm_id={}).",
+                              node_id,
+                              err,
+                              id_);
+            }
+        }
+
+        void releaseNodeContext(const sdk::CyphalNodeId node_id)
+        {
+            node_id_to_cnxt_.erase(node_id);
+            if (node_id_to_cnxt_.empty())
+            {
+                complete(0);
+            }
         }
 
         void complete(const int err_code)
         {
             // Cancel anything that might be still pending.
-            node_id_to_op_.clear();
+            node_id_to_cnxt_.clear();
 
             if (const auto err = channel_.complete(err_code))
             {
@@ -257,10 +342,11 @@ private:
             service_.releaseFsmBy(id_);
         }
 
-        const Id                                        id_;
-        Channel                                         channel_;
-        ExecCmdServiceImpl&                             service_;
-        std::unordered_map<sdk::CyphalNodeId, CyNodeOp> node_id_to_op_;
+        const Id                                           id_;
+        Channel                                            channel_;
+        ExecCmdServiceImpl&                                service_;
+        bool                                               processing_;
+        std::unordered_map<sdk::CyphalNodeId, NodeContext> node_id_to_cnxt_;
 
     };  // Fsm
 

--- a/src/daemon/engine/svc/node/exec_cmd_service.cpp
+++ b/src/daemon/engine/svc/node/exec_cmd_service.cpp
@@ -140,7 +140,7 @@ private:
             return service_.context_.memory;
         }
 
-        // We are not interested in handling this events.
+        // We are not interested in handling this event.
         static void handleEvent(const Channel::Connected&) {}
 
         void handleEvent(const Channel::Input& input)
@@ -148,7 +148,7 @@ private:
             CETL_DEBUG_ASSERT(!processing_, "");
             if (processing_)
             {
-                logger().warn("ExecCmdSvc: Ignoring extra input - already processing (id={}).", id_);
+                logger().warn("ExecCmdSvc: Ignoring extra input - already processing (fsm_id={}).", id_);
                 return;
             }
 
@@ -163,25 +163,25 @@ private:
 
         void handleEvent(const Channel::Completed& completed)
         {
-            logger().debug("ExecCmdSvc::handleEvent({}) (id={}).", completed, id_);
+            logger().debug("ExecCmdSvc::handleEvent({}) (fsm_id={}).", completed, id_);
 
             if (!completed.keep_alive)
             {
-                logger().warn("ExecCmdSvc: canceling processing (id={}).", id_);
+                logger().warn("ExecCmdSvc: canceling processing (fsm_id={}).", id_);
                 complete(sdk::ErrorCode::Canceled);
                 return;
             }
 
             if (processing_)
             {
-                logger().warn("ExecCmdSvc: Ignoring extra channel completion - already processing (id={}).", id_);
+                logger().warn("ExecCmdSvc: Ignoring extra channel completion - already processing (fsm_id={}).", id_);
                 return;
             }
             processing_ = true;
 
             if (node_id_to_cnxt_.empty())
             {
-                logger().debug("ExecCmdSvc: Nothing to do - empty working set (id={}, nodes={}).",
+                logger().debug("ExecCmdSvc: Nothing to do - empty working set (fsm_id={}, nodes={}).",
                                id_,
                                node_id_to_cnxt_.size());
                 complete(sdk::ErrorCode::Success);

--- a/src/daemon/engine/svc/node/exec_cmd_service.cpp
+++ b/src/daemon/engine/svc/node/exec_cmd_service.cpp
@@ -211,6 +211,8 @@ private:
         {
             using CyMakeFailure = libcyphal::presentation::Presentation::MakeFailure;
 
+            CETL_DEBUG_ASSERT(processing_, "");
+
             const auto it = node_id_to_cnxt_.find(node_id);
             if (it == node_id_to_cnxt_.end())
             {
@@ -240,6 +242,11 @@ private:
         {
             CETL_DEBUG_ASSERT(processing_, "");
             CETL_DEBUG_ASSERT(node_cnxt.client, "");
+            if (!node_cnxt.client)
+            {
+                releaseNodeContext(node_id);
+                return;
+            }
 
             const auto                  deadline = service_.context_.executor.now() + node_cnxt.timeout;
             const CyExecCmdSvc::Request cy_request{node_cnxt.payload.command, node_cnxt.payload.parameter, &memory()};

--- a/src/daemon/engine/svc/node/list_registers_service.cpp
+++ b/src/daemon/engine/svc/node/list_registers_service.cpp
@@ -20,7 +20,6 @@
 #include <libcyphal/presentation/presentation.hpp>
 #include <libcyphal/presentation/response_promise.hpp>
 
-#include <cerrno>
 #include <chrono>
 #include <cstdint>
 #include <memory>

--- a/src/daemon/engine/svc/node/list_registers_service.cpp
+++ b/src/daemon/engine/svc/node/list_registers_service.cpp
@@ -103,10 +103,7 @@ private:
             });
         }
 
-        ~Fsm()
-        {
-            logger().trace("ListRegsSvc::~Fsm (id={}).", id_);
-        }
+        ~Fsm() = default;
 
         Fsm(const Fsm&)                = delete;
         Fsm(Fsm&&) noexcept            = delete;

--- a/src/daemon/main.cpp
+++ b/src/daemon/main.cpp
@@ -11,7 +11,6 @@
 
 #include <array>
 #include <cassert>
-#include <cerrno>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>

--- a/src/sdk/file_server.cpp
+++ b/src/sdk/file_server.cpp
@@ -65,7 +65,7 @@ public:
         if (path.size() > Request::_traits_::TypeOf::item::_traits_::ArrayCapacity::path)
         {
             logger_->error("Too long path '{}'.", path);
-            return just<PopRoot::Result>(EINVAL);
+            return just<PopRoot::Result>(ErrorCode::InvalidArgument);
         }
 
         common::svc::file_server::PopRootSpec::Request request{&memory_};
@@ -89,7 +89,7 @@ public:
         if (path.size() > Request::_traits_::TypeOf::item::_traits_::ArrayCapacity::path)
         {
             logger_->error("Too long path '{}'.", path);
-            return just<PopRoot::Result>(EINVAL);
+            return just<PopRoot::Result>(ErrorCode::InvalidArgument);
         }
 
         Request request{&memory_};

--- a/src/sdk/node_command_client.cpp
+++ b/src/sdk/node_command_client.cpp
@@ -52,12 +52,7 @@ public:
                                                const Command::NodeRequest&     node_request,
                                                const std::chrono::microseconds timeout) override
     {
-        common::svc::node::ExecCmdSpec::Request request{std::max<std::uint64_t>(0, timeout.count()),
-                                                        {node_ids.begin(), node_ids.end(), &memory_},
-                                                        {node_request.command, node_request.parameter, &memory_},
-                                                        &memory_};
-
-        auto svc_client = ExecCmdClient::make(memory_, ipc_router_, std::move(request));
+        auto svc_client = ExecCmdClient::make(memory_, ipc_router_, node_ids, node_request, timeout);
 
         return std::make_unique<CommandSender>(std::move(svc_client));
     }

--- a/src/sdk/node_command_client.cpp
+++ b/src/sdk/node_command_client.cpp
@@ -17,9 +17,7 @@
 #include <cetl/pf17/cetlpf.hpp>
 
 #include <algorithm>
-#include <cerrno>
 #include <chrono>
-#include <cstdint>
 #include <functional>
 #include <memory>
 #include <utility>

--- a/src/sdk/node_command_client.cpp
+++ b/src/sdk/node_command_client.cpp
@@ -50,6 +50,8 @@ public:
                                                const Command::NodeRequest&     node_request,
                                                const std::chrono::microseconds timeout) override
     {
+        logger_->trace("NodeCommandClient: Making sender of `sendCommand()`.");
+
         auto svc_client = ExecCmdClient::make(memory_, ipc_router_, node_ids, node_request, timeout);
 
         return std::make_unique<CommandSender>(std::move(svc_client));

--- a/src/sdk/node_registry_client.cpp
+++ b/src/sdk/node_registry_client.cpp
@@ -72,7 +72,7 @@ public:
             if (reg_key.size() > RegKey::_traits_::ArrayCapacity::name)
             {
                 logger_->error("Too long register key '{}'.", reg_key);
-                return just<Access::Result>(EINVAL);
+                return just<Access::Result>(ErrorCode::InvalidArgument);
             }
         }
 
@@ -98,7 +98,7 @@ public:
             if (reg.key.size() > RegKey::_traits_::ArrayCapacity::name)
             {
                 logger_->error("Too long register key '{}'.", reg.key);
-                return just<Access::Result>(EINVAL);
+                return just<Access::Result>(ErrorCode::InvalidArgument);
             }
         }
 

--- a/src/sdk/node_registry_client.cpp
+++ b/src/sdk/node_registry_client.cpp
@@ -43,14 +43,10 @@ public:
     SenderOf<List::Result>::Ptr list(const CyphalNodeIds node_ids, const std::chrono::microseconds timeout) override
     {
         using ListRegistersClient = svc::node::ListRegistersClient;
-        using Request             = common::svc::node::ListRegistersSpec::Request;
 
         logger_->trace("NodeRegistryClient: Making sender of `list()`.");
 
-        Request request{std::max<std::uint64_t>(0, timeout.count()),
-                        {node_ids.begin(), node_ids.end(), &memory_},
-                        &memory_};
-        auto    svc_client = ListRegistersClient::make(ipc_router_, std::move(request));
+        auto svc_client = ListRegistersClient::make(memory_, ipc_router_, node_ids, timeout);
 
         return std::make_unique<svc::AsSender<ListRegistersClient, ListRegistersClient::Result>>(  //
             "NodeRegistryClient::list",
@@ -91,7 +87,7 @@ public:
         using RegKey                = uavcan::_register::Name_1_0;
         using AccessRegistersClient = svc::node::AccessRegistersClient;
 
-        logger_->trace("NodeRegistryClient: Making sender of `read()`.");
+        logger_->trace("NodeRegistryClient: Making sender of `write()`.");
 
         for (const auto& reg : registers)
         {

--- a/src/sdk/svc/file_server/list_roots_client.cpp
+++ b/src/sdk/svc/file_server/list_roots_client.cpp
@@ -9,6 +9,7 @@
 #include "ipc/client_router.hpp"
 #include "ipc/ipc_types.hpp"
 #include "logging.hpp"
+#include "ocvsmd/sdk/defines.hpp"
 #include "svc/file_server/list_roots_spec.hpp"
 
 #include <cetl/cetl.hpp>
@@ -63,11 +64,12 @@ private:
     {
         logger_->trace("ListRootsClient::handleEvent({}).", connected);
 
-        if (const auto err = channel_.send(request_))
+        const auto error_code = channel_.send(request_);
+        if (error_code != ErrorCode::Success)
         {
             CETL_DEBUG_ASSERT(receiver_, "");
 
-            receiver_(Failure{err});
+            receiver_(Failure{error_code});
         }
     }
 
@@ -84,9 +86,9 @@ private:
 
         logger_->debug("ListRootsClient::handleEvent({}).", completed);
 
-        if (completed.error_code != common::ipc::ErrorCode::Success)
+        if (completed.error_code != ErrorCode::Success)
         {
-            receiver_(static_cast<Failure>(completed.error_code));
+            receiver_(Failure{completed.error_code});
             return;
         }
         receiver_(Success{std::move(items_)});

--- a/src/sdk/svc/file_server/list_roots_client.hpp
+++ b/src/sdk/svc/file_server/list_roots_client.hpp
@@ -7,6 +7,7 @@
 #define OCVSMD_SDK_SVC_FILE_SERVER_LIST_ROOTS_CLIENT_HPP_INCLUDED
 
 #include "ipc/client_router.hpp"
+#include "ocvsmd/sdk/defines.hpp"
 #include "svc/file_server/list_roots_spec.hpp"
 
 #include <cetl/cetl.hpp>
@@ -36,7 +37,7 @@ public:
     using Spec = common::svc::file_server::ListRootsSpec;
 
     using Success = std::vector<std::string>;
-    using Failure = int;  // `errno`-like error code
+    using Failure = ErrorCode;
     using Result  = cetl::variant<Success, Failure>;
 
     CETL_NODISCARD static Ptr make(cetl::pmr::memory_resource&           memory,

--- a/src/sdk/svc/file_server/pop_root_client.cpp
+++ b/src/sdk/svc/file_server/pop_root_client.cpp
@@ -9,6 +9,7 @@
 #include "ipc/client_router.hpp"
 #include "ipc/ipc_types.hpp"
 #include "logging.hpp"
+#include "ocvsmd/sdk/defines.hpp"
 #include "svc/file_server/pop_root_spec.hpp"
 
 #include <cetl/cetl.hpp>
@@ -62,11 +63,12 @@ private:
     {
         logger_->trace("PopRootClient::handleEvent({}).", connected);
 
-        if (const auto err = channel_.send(request_))
+        const auto error_code = channel_.send(request_);
+        if (error_code != ErrorCode::Success)
         {
             CETL_DEBUG_ASSERT(receiver_, "");
 
-            receiver_(Failure{err});
+            receiver_(Failure{error_code});
         }
     }
 
@@ -79,12 +81,12 @@ private:
     {
         CETL_DEBUG_ASSERT(receiver_, "");
 
-        if (completed.error_code != common::ipc::ErrorCode::Success)
+        if (completed.error_code != ErrorCode::Success)
         {
-            receiver_(static_cast<Failure>(completed.error_code));
+            receiver_(Failure{completed.error_code});
             return;
         }
-        receiver_({});
+        receiver_(Success{});
     }
 
     cetl::pmr::memory_resource&   memory_;

--- a/src/sdk/svc/file_server/pop_root_client.hpp
+++ b/src/sdk/svc/file_server/pop_root_client.hpp
@@ -7,6 +7,7 @@
 #define OCVSMD_SDK_SVC_FILE_SERVER_POP_ROOT_CLIENT_HPP_INCLUDED
 
 #include "ipc/client_router.hpp"
+#include "ocvsmd/sdk/defines.hpp"
 #include "svc/file_server/pop_root_spec.hpp"
 
 #include <cetl/cetl.hpp>
@@ -34,7 +35,7 @@ public:
     using Spec = common::svc::file_server::PopRootSpec;
 
     using Success = cetl::monostate;
-    using Failure = int;  // `errno`-like error code
+    using Failure = ErrorCode;
     using Result  = cetl::variant<Success, Failure>;
 
     CETL_NODISCARD static Ptr make(cetl::pmr::memory_resource&           memory,

--- a/src/sdk/svc/file_server/push_root_client.cpp
+++ b/src/sdk/svc/file_server/push_root_client.cpp
@@ -9,6 +9,7 @@
 #include "ipc/client_router.hpp"
 #include "ipc/ipc_types.hpp"
 #include "logging.hpp"
+#include "ocvsmd/sdk/defines.hpp"
 #include "svc/file_server/push_root_spec.hpp"
 
 #include <cetl/cetl.hpp>
@@ -62,11 +63,12 @@ private:
     {
         logger_->trace("PushRootClient::handleEvent({}).", connected);
 
-        if (const auto err = channel_.send(request_))
+        const auto error_code = channel_.send(request_);
+        if (error_code != ErrorCode::Success)
         {
             CETL_DEBUG_ASSERT(receiver_, "");
 
-            receiver_(Failure{err});
+            receiver_(Failure{error_code});
         }
     }
 
@@ -79,12 +81,12 @@ private:
     {
         CETL_DEBUG_ASSERT(receiver_, "");
 
-        if (completed.error_code != common::ipc::ErrorCode::Success)
+        if (completed.error_code != ErrorCode::Success)
         {
-            receiver_(static_cast<Failure>(completed.error_code));
+            receiver_(Failure{completed.error_code});
             return;
         }
-        receiver_({});
+        receiver_(Success{});
     }
 
     cetl::pmr::memory_resource&   memory_;

--- a/src/sdk/svc/file_server/push_root_client.hpp
+++ b/src/sdk/svc/file_server/push_root_client.hpp
@@ -7,6 +7,7 @@
 #define OCVSMD_SDK_SVC_FILE_SERVER_PUSH_ROOT_CLIENT_HPP_INCLUDED
 
 #include "ipc/client_router.hpp"
+#include "ocvsmd/sdk/defines.hpp"
 #include "svc/file_server/push_root_spec.hpp"
 
 #include <cetl/cetl.hpp>
@@ -34,7 +35,7 @@ public:
     using Spec = common::svc::file_server::PushRootSpec;
 
     using Success = cetl::monostate;
-    using Failure = int;  // `errno`-like error code
+    using Failure = ErrorCode;
     using Result  = cetl::variant<Success, Failure>;
 
     CETL_NODISCARD static Ptr make(cetl::pmr::memory_resource&           memory,

--- a/src/sdk/svc/node/access_registers_client.cpp
+++ b/src/sdk/svc/node/access_registers_client.cpp
@@ -227,11 +227,12 @@ AccessRegistersClient::Ptr AccessRegistersClient::make(  //
     return std::make_shared<AccessRegistersClientImpl>(memory, ipc_router, node_ids, registers, timeout);
 }
 
-AccessRegistersClient::Ptr AccessRegistersClient::make(cetl::pmr::memory_resource&           memory,
-                                                       const common::ipc::ClientRouter::Ptr& ipc_router,
-                                                       const CyphalNodeIds                   node_ids,
-                                                       const cetl::span<const RegKeyValue>   registers,
-                                                       const std::chrono::microseconds       timeout)
+AccessRegistersClient::Ptr AccessRegistersClient::make(  //
+    cetl::pmr::memory_resource&           memory,
+    const common::ipc::ClientRouter::Ptr& ipc_router,
+    const CyphalNodeIds                   node_ids,
+    const cetl::span<const RegKeyValue>   registers,
+    const std::chrono::microseconds       timeout)
 {
     return std::make_shared<AccessRegistersClientImpl>(memory, ipc_router, node_ids, registers, timeout);
 }

--- a/src/sdk/svc/node/exec_cmd_client.cpp
+++ b/src/sdk/svc/node/exec_cmd_client.cpp
@@ -87,20 +87,22 @@ private:
 
         for (const auto& request : requests_)
         {
-            if (const auto err = channel_.send(request))
+            const auto failure = channel_.send(request);
+            if (failure != ErrorCode::Success)
             {
                 CETL_DEBUG_ASSERT(receiver_, "");
 
-                receiver_(Failure{err});
+                receiver_(failure);
                 return;
             }
         }
 
         // Let the server know that all requests have been sent.
         //
-        if (const auto err = channel_.complete(0, true))
+        const auto failure = channel_.complete(ErrorCode::Success, true);
+        if (failure != ErrorCode::Success)
         {
-            receiver_(Failure{err});
+            receiver_(failure);
         }
     }
 
@@ -114,7 +116,7 @@ private:
                           input.node_id,
                           input.error_code);
 
-            node_id_to_response_.emplace(input.node_id, input.error_code);
+            node_id_to_response_.emplace(input.node_id, static_cast<ErrorCode>(input.error_code));
             return;
         }
 
@@ -128,9 +130,9 @@ private:
 
         logger_->debug("ExecCmdClient::handleEvent({}).", completed);
 
-        if (completed.error_code != common::ipc::ErrorCode::Success)
+        if (completed.error_code != ErrorCode::Success)
         {
-            receiver_(static_cast<Failure>(completed.error_code));
+            receiver_(Failure{completed.error_code});
             return;
         }
         receiver_(std::move(node_id_to_response_));

--- a/src/sdk/svc/node/exec_cmd_client.cpp
+++ b/src/sdk/svc/node/exec_cmd_client.cpp
@@ -7,7 +7,6 @@
 
 #include "ipc/channel.hpp"
 #include "ipc/client_router.hpp"
-#include "ipc/ipc_types.hpp"
 #include "logging.hpp"
 #include "svc/node/exec_cmd_spec.hpp"
 

--- a/src/sdk/svc/node/exec_cmd_client.cpp
+++ b/src/sdk/svc/node/exec_cmd_client.cpp
@@ -19,6 +19,7 @@
 #include <functional>
 #include <memory>
 #include <utility>
+#include <vector>
 
 namespace ocvsmd
 {
@@ -36,12 +37,14 @@ class ExecCmdClientImpl final : public ExecCmdClient
 public:
     ExecCmdClientImpl(cetl::pmr::memory_resource&           memory,
                       const common::ipc::ClientRouter::Ptr& ipc_router,
-                      Spec::Request&&                       request)
+                      const CyphalNodeIds                   node_ids,
+                      const NodeRequest&                    node_request,
+                      const std::chrono::microseconds       timeout)
         : memory_{memory}
         , logger_{common::getLogger("svc")}
-        , request_{std::move(request)}
         , channel_{ipc_router->makeChannel<Channel>(Spec::svc_full_name())}
     {
+        buildRequests(node_ids, node_request, timeout);
     }
 
     void submitImpl(std::function<void(Result&&)>&& receiver) override
@@ -57,14 +60,46 @@ public:
 private:
     using Channel = common::ipc::Channel<Spec::Response, Spec::Request>;
 
+    void buildRequests(const CyphalNodeIds             node_ids,
+                       const NodeRequest&              node_request,
+                       const std::chrono::microseconds timeout)
+    {
+        const auto timeout_us = std::max<std::uint64_t>(0, timeout.count());
+
+        // Split the whole span of node ids into chunks of `ArrayCapacity::node_ids` size.
+        //
+        constexpr std::size_t chunk_size = Spec::Request::_traits_::ArrayCapacity::node_ids;
+        for (std::size_t offset = 0; offset < node_ids.size(); offset += chunk_size)
+        {
+            Spec::Request request{&memory_};
+            request.timeout_us   = timeout_us;
+            request.payload      = {node_request.command, node_request.parameter, &memory_};
+            const auto ids_chunk = node_ids.subspan(offset, std::min(chunk_size, node_ids.size() - offset));
+            std::copy(ids_chunk.begin(), ids_chunk.end(), std::back_inserter(request.node_ids));
+
+            requests_.emplace_back(std::move(request));
+        }
+    }
+
     void handleEvent(const Channel::Connected& connected)
     {
         logger_->trace("ExecCmdClient::handleEvent({}).", connected);
 
-        if (const auto err = channel_.send(request_))
+        for (const auto& request : requests_)
         {
-            CETL_DEBUG_ASSERT(receiver_, "");
+            if (const auto err = channel_.send(request))
+            {
+                CETL_DEBUG_ASSERT(receiver_, "");
 
+                receiver_(Failure{err});
+                return;
+            }
+        }
+
+        // Let the server know that all requests have been sent.
+        //
+        if (const auto err = channel_.complete(0, true))
+        {
             receiver_(Failure{err});
         }
     }
@@ -73,7 +108,17 @@ private:
     {
         logger_->trace("ExecCmdClient::handleEvent(Input).");
 
-        NodeResponse node_response{input.payload.status, input.payload.output, &memory_};
+        if (input.error_code != 0)
+        {
+            logger_->warn("ExecCmdClient::handleEvent(Input) - Node {} has failed (err={}).",
+                          input.node_id,
+                          input.error_code);
+
+            node_id_to_response_.emplace(input.node_id, input.error_code);
+            return;
+        }
+
+        NodeResponse::Success node_response{input.payload.status, input.payload.output, &memory_};
         node_id_to_response_.emplace(input.node_id, std::move(node_response));
     }
 
@@ -93,7 +138,7 @@ private:
 
     cetl::pmr::memory_resource&   memory_;
     common::LoggerPtr             logger_;
-    Spec::Request                 request_;
+    std::vector<Spec::Request>    requests_;
     Channel                       channel_;
     std::function<void(Result&&)> receiver_;
     Success                       node_id_to_response_;
@@ -105,9 +150,11 @@ private:
 ExecCmdClient::Ptr ExecCmdClient::make(  //
     cetl::pmr::memory_resource&           memory,
     const common::ipc::ClientRouter::Ptr& ipc_router,
-    Spec::Request&&                       request)
+    const CyphalNodeIds                   node_ids,
+    const NodeRequest&                    node_request,
+    const std::chrono::microseconds       timeout)
 {
-    return std::make_shared<ExecCmdClientImpl>(memory, ipc_router, std::move(request));
+    return std::make_shared<ExecCmdClientImpl>(memory, ipc_router, node_ids, node_request, timeout);
 }
 
 }  // namespace node

--- a/src/sdk/svc/node/exec_cmd_client.hpp
+++ b/src/sdk/svc/node/exec_cmd_client.hpp
@@ -8,6 +8,7 @@
 
 #include "ipc/client_router.hpp"
 #include "ocvsmd/sdk/defines.hpp"
+#include "ocvsmd/sdk/node_command_client.hpp"
 #include "svc/node/exec_cmd_spec.hpp"
 
 #include <uavcan/node/ExecuteCommand_1_3.hpp>
@@ -33,17 +34,20 @@ namespace node
 class ExecCmdClient
 {
 public:
-    using Ptr          = std::shared_ptr<ExecCmdClient>;
-    using Spec         = common::svc::node::ExecCmdSpec;
-    using NodeResponse = uavcan::node::ExecuteCommand_1_3::Response;
+    using Ptr  = std::shared_ptr<ExecCmdClient>;
+    using Spec = common::svc::node::ExecCmdSpec;
 
-    using Success = std::unordered_map<CyphalNodeId, NodeResponse>;
-    using Failure = int;  // `errno`-like error code
-    using Result  = cetl::variant<Success, Failure>;
+    using Result       = NodeCommandClient::Command::Result;
+    using Success      = NodeCommandClient::Command::Success;
+    using Failure      = NodeCommandClient::Command::Failure;
+    using NodeRequest  = NodeCommandClient::Command::NodeRequest;
+    using NodeResponse = NodeCommandClient::Command::NodeResponse;
 
     CETL_NODISCARD static Ptr make(cetl::pmr::memory_resource&           memory,
                                    const common::ipc::ClientRouter::Ptr& ipc_router,
-                                   Spec::Request&&                       request);
+                                   const CyphalNodeIds                   node_ids,
+                                   const NodeRequest&                    node_request,
+                                   const std::chrono::microseconds       timeout);
 
     ExecCmdClient(ExecCmdClient&&)                 = delete;
     ExecCmdClient(const ExecCmdClient&)            = delete;

--- a/src/sdk/svc/node/list_registers_client.cpp
+++ b/src/sdk/svc/node/list_registers_client.cpp
@@ -7,16 +7,15 @@
 
 #include "ipc/channel.hpp"
 #include "ipc/client_router.hpp"
-#include "ipc/ipc_types.hpp"
 #include "logging.hpp"
 #include "svc/node/list_registers_spec.hpp"
 
 #include <cetl/cetl.hpp>
-#include <cetl/pf17/cetlpf.hpp>
 
 #include <functional>
 #include <memory>
 #include <utility>
+#include <vector>
 
 namespace ocvsmd
 {
@@ -32,11 +31,15 @@ namespace
 class ListRegistersClientImpl final : public ListRegistersClient
 {
 public:
-    ListRegistersClientImpl(const common::ipc::ClientRouter::Ptr& ipc_router, Spec::Request&& request)
-        : logger_{common::getLogger("svc")}
-        , request_{std::move(request)}
+    ListRegistersClientImpl(cetl::pmr::memory_resource&           memory,
+                            const common::ipc::ClientRouter::Ptr& ipc_router,
+                            const CyphalNodeIds                   node_ids,
+                            const std::chrono::microseconds       timeout)
+        : memory_{memory}
+        , logger_{common::getLogger("svc")}
         , channel_{ipc_router->makeChannel<Channel>(Spec::svc_full_name())}
     {
+        buildRequests(node_ids, timeout);
     }
 
     void submitImpl(std::function<void(Result&&)>&& receiver) override
@@ -53,16 +56,46 @@ private:
     using Channel       = common::ipc::Channel<Spec::Response, Spec::Request>;
     using NodeRegisters = NodeRegistryClient::List::NodeRegisters;
 
+    void buildRequests(const CyphalNodeIds node_ids, const std::chrono::microseconds timeout)
+    {
+        const auto timeout_us = std::max<std::uint64_t>(0, timeout.count());
+
+        // Split the whole span of node ids into chunks of `ArrayCapacity::node_ids` size.
+        //
+        constexpr std::size_t chunk_size = Spec::Request::_traits_::ArrayCapacity::node_ids;
+        for (std::size_t offset = 0; offset < node_ids.size(); offset += chunk_size)
+        {
+            Spec::Request request{&memory_};
+            request.timeout_us   = timeout_us;
+            const auto ids_chunk = node_ids.subspan(offset, std::min(chunk_size, node_ids.size() - offset));
+            std::copy(ids_chunk.begin(), ids_chunk.end(), std::back_inserter(request.node_ids));
+
+            requests_.emplace_back(std::move(request));
+        }
+    }
+
     void handleEvent(const Channel::Connected& connected)
     {
         logger_->trace("ListRegistersClient::handleEvent({}).", connected);
 
-        const auto error_code = channel_.send(request_);
-        if (error_code != ErrorCode::Success)
+        for (const auto& request : requests_)
         {
-            CETL_DEBUG_ASSERT(receiver_, "");
+            const auto failure = channel_.send(request);
+            if (failure != ErrorCode::Success)
+            {
+                CETL_DEBUG_ASSERT(receiver_, "");
 
-            receiver_(error_code);
+                receiver_(failure);
+                return;
+            }
+        }
+
+        // Let the server know that all requests have been sent.
+        //
+        const auto failure = channel_.complete(ErrorCode::Success, true);
+        if (failure != ErrorCode::Success)
+        {
+            receiver_(failure);
         }
     }
 
@@ -106,8 +139,9 @@ private:
         receiver_(std::move(node_id_to_registers_));
     }
 
+    cetl::pmr::memory_resource&   memory_;
     common::LoggerPtr             logger_;
-    Spec::Request                 request_;
+    std::vector<Spec::Request>    requests_;
     Channel                       channel_;
     std::function<void(Result&&)> receiver_;
     Success                       node_id_to_registers_;
@@ -117,10 +151,12 @@ private:
 }  // namespace
 
 ListRegistersClient::Ptr ListRegistersClient::make(  //
+    cetl::pmr::memory_resource&           memory,
     const common::ipc::ClientRouter::Ptr& ipc_router,
-    Spec::Request&&                       request)
+    const CyphalNodeIds                   node_ids,
+    const std::chrono::microseconds       timeout)
 {
-    return std::make_shared<ListRegistersClientImpl>(ipc_router, std::move(request));
+    return std::make_shared<ListRegistersClientImpl>(memory, ipc_router, node_ids, timeout);
 }
 
 }  // namespace node

--- a/src/sdk/svc/node/list_registers_client.cpp
+++ b/src/sdk/svc/node/list_registers_client.cpp
@@ -57,11 +57,12 @@ private:
     {
         logger_->trace("ListRegistersClient::handleEvent({}).", connected);
 
-        if (const auto err = channel_.send(request_))
+        const auto error_code = channel_.send(request_);
+        if (error_code != ErrorCode::Success)
         {
             CETL_DEBUG_ASSERT(receiver_, "");
 
-            receiver_(Failure{err});
+            receiver_(error_code);
         }
     }
 
@@ -75,7 +76,7 @@ private:
                           input.node_id,
                           input.error_code);
 
-            node_id_to_registers_.emplace(input.node_id, input.error_code);
+            node_id_to_registers_.emplace(input.node_id, static_cast<ErrorCode>(input.error_code));
             return;
         }
 
@@ -97,9 +98,9 @@ private:
 
         logger_->debug("ListRegistersClient::handleEvent({}).", completed);
 
-        if (completed.error_code != common::ipc::ErrorCode::Success)
+        if (completed.error_code != ErrorCode::Success)
         {
-            receiver_(static_cast<Failure>(completed.error_code));
+            receiver_(Failure{completed.error_code});
             return;
         }
         receiver_(std::move(node_id_to_registers_));

--- a/src/sdk/svc/node/list_registers_client.hpp
+++ b/src/sdk/svc/node/list_registers_client.hpp
@@ -36,7 +36,10 @@ public:
     using Success = NodeRegistryClient::List::Success;
     using Failure = NodeRegistryClient::List::Failure;
 
-    CETL_NODISCARD static Ptr make(const common::ipc::ClientRouter::Ptr& ipc_router, Spec::Request&& request);
+    CETL_NODISCARD static Ptr make(cetl::pmr::memory_resource&           memory,
+                                   const common::ipc::ClientRouter::Ptr& ipc_router,
+                                   const CyphalNodeIds                   node_ids,
+                                   const std::chrono::microseconds       timeout);
 
     ListRegistersClient(ListRegistersClient&&)                 = delete;
     ListRegistersClient(const ListRegistersClient&)            = delete;

--- a/test/common/io/test_socket_address.cpp
+++ b/test/common/io/test_socket_address.cpp
@@ -12,7 +12,6 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-#include <cerrno>
 #include <netinet/in.h>
 #include <string>
 #include <sys/socket.h>

--- a/test/common/io/test_socket_address.cpp
+++ b/test/common/io/test_socket_address.cpp
@@ -5,6 +5,8 @@
 
 #include "io/socket_address.hpp"
 
+#include "ocvsmd/sdk/defines.hpp"
+
 #include <cetl/pf17/cetlpf.hpp>
 
 #include <gmock/gmock.h>
@@ -20,6 +22,7 @@ namespace
 {
 
 using namespace ocvsmd::common::io;  // NOLINT This our main concern here in the unit tests.
+using ocvsmd::sdk::ErrorCode;
 
 using testing::_;
 using testing::VariantWith;
@@ -67,7 +70,7 @@ TEST_F(TestSocketAddress, parse_unix_domain)
     {
         const std::string too_long_path(MaxPath, 'x');
         auto              maybe_socket_addr = SocketAddress::parse("unix:" + too_long_path, 0);
-        ASSERT_THAT(maybe_socket_addr, VariantWith<Result::Failure>(EINVAL));
+        ASSERT_THAT(maybe_socket_addr, VariantWith<Result::Failure>(ErrorCode::InvalidArgument));
     }
 }
 
@@ -121,7 +124,7 @@ TEST_F(TestSocketAddress, parse_abstract_unix_domain)
     {
         const std::string too_long_path(MaxPath - 1, 'x');
         auto              maybe_socket_addr = SocketAddress::parse("unix-abstract:" + too_long_path, 0);
-        ASSERT_THAT(maybe_socket_addr, VariantWith<Result::Failure>(EINVAL));
+        ASSERT_THAT(maybe_socket_addr, VariantWith<Result::Failure>(ErrorCode::InvalidArgument));
     }
 }
 
@@ -160,14 +163,14 @@ TEST_F(TestSocketAddress, parse_ipv4)
     {
         const std::string test_addr         = "tcp://127.0.0.256";
         auto              maybe_socket_addr = SocketAddress::parse(test_addr, 80);
-        ASSERT_THAT(maybe_socket_addr, VariantWith<Result::Failure>(EINVAL));
+        ASSERT_THAT(maybe_socket_addr, VariantWith<Result::Failure>(ErrorCode::InvalidArgument));
     }
 
     // try unsupported
     {
         const std::string test_addr         = "tcp://localhost";
         auto              maybe_socket_addr = SocketAddress::parse(test_addr, 80);
-        ASSERT_THAT(maybe_socket_addr, VariantWith<Result::Failure>(EINVAL));
+        ASSERT_THAT(maybe_socket_addr, VariantWith<Result::Failure>(ErrorCode::InvalidArgument));
     }
 }
 
@@ -207,16 +210,19 @@ TEST_F(TestSocketAddress, parse_ipv6)
     // try invalid
     {
         // missing closing bracket
-        ASSERT_THAT(SocketAddress::parse("tcp://[::1", 0), VariantWith<Result::Failure>(EINVAL));
+        ASSERT_THAT(SocketAddress::parse("tcp://[::1", 0), VariantWith<Result::Failure>(ErrorCode::InvalidArgument));
 
         // missing colon after bracket
-        ASSERT_THAT(SocketAddress::parse("tcp://[::1]8080", 0), VariantWith<Result::Failure>(EINVAL));
+        ASSERT_THAT(SocketAddress::parse("tcp://[::1]8080", 0),
+                    VariantWith<Result::Failure>(ErrorCode::InvalidArgument));
 
         // invalid port number
-        ASSERT_THAT(SocketAddress::parse("tcp://[::1]:80_80", 0), VariantWith<Result::Failure>(EINVAL));
+        ASSERT_THAT(SocketAddress::parse("tcp://[::1]:80_80", 0),
+                    VariantWith<Result::Failure>(ErrorCode::InvalidArgument));
 
         // too big port number
-        ASSERT_THAT(SocketAddress::parse("tcp://[::1]:65536", 0), VariantWith<Result::Failure>(EINVAL));
+        ASSERT_THAT(SocketAddress::parse("tcp://[::1]:65536", 0),
+                    VariantWith<Result::Failure>(ErrorCode::InvalidArgument));
     }
 }
 

--- a/test/common/ipc/gateway_mock.hpp
+++ b/test/common/ipc/gateway_mock.hpp
@@ -7,6 +7,7 @@
 #define OCVSMD_COMMON_IPC_GATEWAY_MOCK_HPP_INCLUDED
 
 #include "ipc/gateway.hpp"
+#include "ocvsmd/sdk/defines.hpp"
 #include "ref_wrapper.hpp"
 
 #include <gmock/gmock.h>
@@ -29,17 +30,17 @@ public:
 
         // MARK: Gateway
 
-        CETL_NODISCARD int send(const ServiceDesc::Id service_id, const Payload payload) override
+        CETL_NODISCARD sdk::ErrorCode send(const ServiceDesc::Id service_id, const Payload payload) override
         {
             return reference().send(service_id, payload);
         }
 
-        CETL_NODISCARD int complete(const int error_code, const bool keep_alive) override
+        CETL_NODISCARD sdk::ErrorCode complete(const sdk::ErrorCode error_code, const bool keep_alive) override
         {
             return reference().complete(error_code, keep_alive);
         }
 
-        CETL_NODISCARD int event(const Event::Var& event) override
+        CETL_NODISCARD sdk::ErrorCode event(const Event::Var& event) override
         {
             return reference().event(event);
         }
@@ -53,9 +54,9 @@ public:
     };  // Wrapper
 
     MOCK_METHOD(void, deinit, (), (const));
-    MOCK_METHOD(int, send, (const ServiceDesc::Id service_id, const Payload payload), (override));
-    MOCK_METHOD(int, complete, (const int error_code, const bool keep_alive), (override));
-    MOCK_METHOD(int, event, (const Event::Var& event), (override));
+    MOCK_METHOD(sdk::ErrorCode, send, (const ServiceDesc::Id service_id, const Payload payload), (override));
+    MOCK_METHOD(sdk::ErrorCode, complete, (const sdk::ErrorCode error_code, const bool keep_alive), (override));
+    MOCK_METHOD(sdk::ErrorCode, event, (const Event::Var& event), (override));
     MOCK_METHOD(void, subscribe, (EventHandler event_handler), (override));
 
     // NOLINTBEGIN

--- a/test/common/ipc/ipc_gtest_helpers.hpp
+++ b/test/common/ipc/ipc_gtest_helpers.hpp
@@ -13,6 +13,7 @@
 #include "ocvsmd/common/ipc/RouteChannelMsg_0_1.hpp"
 #include "ocvsmd/common/ipc/RouteConnect_0_1.hpp"
 #include "ocvsmd/common/ipc/Route_0_2.hpp"
+#include "ocvsmd/sdk/defines.hpp"
 
 #include <uavcan/node/Version_1_0.hpp>
 #include <uavcan/primitive/Empty_1_0.hpp>
@@ -234,7 +235,7 @@ testing::PolymorphicMatcher<PayloadVariantMatcher<Msg>> PayloadVariantWith(
 inline auto PayloadOfRouteConnect(cetl::pmr::memory_resource& mr,
                                   const std::uint8_t          ver_major  = VERSION_MAJOR,
                                   const std::uint8_t          ver_minor  = VERSION_MINOR,
-                                  ErrorCode                   error_code = ErrorCode::Success)
+                                  const sdk::ErrorCode        error_code = sdk::ErrorCode::Success)
 {
     const RouteConnect_0_1 route_conn{{ver_major, ver_minor, &mr}, static_cast<std::int32_t>(error_code), &mr};
     return PayloadVariantWith<Route_0_2>(mr, testing::VariantWith<RouteConnect_0_1>(route_conn));
@@ -253,15 +254,15 @@ auto PayloadOfRouteChannelMsg(const Msg&                  msg,
                     [&route_ch_msg](const auto payload) {
                         //
                         route_ch_msg.payload_size = payload.size();
-                        return 0;
+                        return ocvsmd::sdk::ErrorCode::Success;
                     }),
-                0);
+                ocvsmd::sdk::ErrorCode::Success);
     return PayloadVariantWith<Route_0_2>(mr, testing::VariantWith<RouteChannelMsg_0_1>(route_ch_msg));
 }
 
 inline auto PayloadOfRouteChannelEnd(cetl::pmr::memory_resource& mr,  //
                                      const std::uint64_t         tag,
-                                     const ErrorCode             error_code,
+                                     const sdk::ErrorCode        error_code,
                                      const bool                  keep_alive = false)
 {
     const RouteChannelEnd_0_2 ch_end{{tag, static_cast<std::int32_t>(error_code), keep_alive, &mr}, &mr};

--- a/test/common/ipc/pipe/client_pipe_mock.hpp
+++ b/test/common/ipc/pipe/client_pipe_mock.hpp
@@ -7,6 +7,7 @@
 #define OCVSMD_COMMON_IPC_CLIENT_PIPE_MOCK_HPP_INCLUDED
 
 #include "ipc/pipe/client_pipe.hpp"
+#include "ocvsmd/sdk/defines.hpp"
 
 #include "ipc/ipc_types.hpp"
 #include "ref_wrapper.hpp"
@@ -31,12 +32,13 @@ public:
 
         // MARK: ClientPipe
 
-        int start(EventHandler event_handler) override
+        sdk::ErrorCode start(EventHandler event_handler) override
         {
             reference().event_handler_ = event_handler;
             return reference().start(event_handler);
         }
-        int send(const Payloads payloads) override
+
+        sdk::ErrorCode send(const Payloads payloads) override
         {
             return reference().send(payloads);
         }
@@ -44,8 +46,8 @@ public:
     };  // Wrapper
 
     MOCK_METHOD(void, deinit, (), (const));
-    MOCK_METHOD(int, start, (EventHandler event_handler), (override));
-    MOCK_METHOD(int, send, (const Payloads payloads), (override));
+    MOCK_METHOD(sdk::ErrorCode, start, (EventHandler event_handler), (override));
+    MOCK_METHOD(sdk::ErrorCode, send, (const Payloads payloads), (override));
 
     // MARK: Data members:
 

--- a/test/common/ipc/pipe/server_pipe_mock.hpp
+++ b/test/common/ipc/pipe/server_pipe_mock.hpp
@@ -7,6 +7,7 @@
 #define OCVSMD_COMMON_IPC_SERVER_PIPE_MOCK_HPP_INCLUDED
 
 #include "ipc/pipe/server_pipe.hpp"
+#include "ocvsmd/sdk/defines.hpp"
 
 #include "ipc/ipc_types.hpp"
 #include "ref_wrapper.hpp"
@@ -31,13 +32,13 @@ public:
 
         // MARK: ServerPipe
 
-        int start(EventHandler event_handler) override
+        sdk::ErrorCode start(EventHandler event_handler) override
         {
             reference().event_handler_ = event_handler;
             return reference().start(event_handler);
         }
 
-        int send(const ClientId client_id, const Payloads payloads) override
+        sdk::ErrorCode send(const ClientId client_id, const Payloads payloads) override
         {
             return reference().send(client_id, payloads);
         }
@@ -45,8 +46,8 @@ public:
     };  // Wrapper
 
     MOCK_METHOD(void, deinit, (), (const));
-    MOCK_METHOD(int, start, (EventHandler event_handler), (override));
-    MOCK_METHOD(int, send, (const ClientId client_id, const Payloads payloads), (override));
+    MOCK_METHOD(sdk::ErrorCode, start, (EventHandler event_handler), (override));
+    MOCK_METHOD(sdk::ErrorCode, send, (const ClientId client_id, const Payloads payloads), (override));
 
     // MARK: Data members:
 

--- a/test/common/ipc/server_router_mock.hpp
+++ b/test/common/ipc/server_router_mock.hpp
@@ -7,6 +7,7 @@
 #define OCVSMD_COMMON_IPC_SERVER_ROUTER_MOCK_HPP_INCLUDED
 
 #include "ipc/server_router.hpp"
+#include "ocvsmd/sdk/defines.hpp"
 
 #include <gmock/gmock.h>
 
@@ -37,7 +38,7 @@ public:
 
     // ServerRouter
 
-    MOCK_METHOD(int, start, (), (override));
+    MOCK_METHOD(sdk::ErrorCode, start, (), (override));
 
     cetl::pmr::memory_resource& memory() override
     {

--- a/test/common/ipc/test_client_router.cpp
+++ b/test/common/ipc/test_client_router.cpp
@@ -23,7 +23,6 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-#include <cerrno>
 #include <cstdint>
 #include <iterator>
 #include <memory>

--- a/test/common/ipc/test_client_router.cpp
+++ b/test/common/ipc/test_client_router.cpp
@@ -16,7 +16,7 @@
 #include "ocvsmd/common/ipc/RouteChannelMsg_0_1.hpp"
 #include "ocvsmd/common/ipc/RouteConnect_0_1.hpp"
 #include "ocvsmd/common/ipc/Route_0_2.hpp"
-#include "ocvsmd/common/svc/node/ExecCmd_0_1.hpp"
+#include "ocvsmd/common/svc/node/ExecCmd_0_2.hpp"
 
 #include <cetl/pf17/cetlpf.hpp>
 
@@ -175,7 +175,7 @@ TEST_F(TestClientRouter, start)
 
 TEST_F(TestClientRouter, makeChannel)
 {
-    using Msg     = ocvsmd::common::svc::node::ExecCmd::Request_0_1;
+    using Msg     = ocvsmd::common::svc::node::ExecCmd::Request_0_2;
     using Channel = Channel<Msg, Msg>;
 
     StrictMock<pipe::ClientPipeMock> client_pipe_mock;
@@ -195,7 +195,7 @@ TEST_F(TestClientRouter, makeChannel)
 
 TEST_F(TestClientRouter, channel_send)
 {
-    using Msg     = ocvsmd::common::svc::node::ExecCmd::Request_0_1;
+    using Msg     = ocvsmd::common::svc::node::ExecCmd::Request_0_2;
     using Channel = Channel<Msg, Msg>;
 
     StrictMock<pipe::ClientPipeMock> client_pipe_mock;
@@ -230,7 +230,7 @@ TEST_F(TestClientRouter, channel_send)
 
 TEST_F(TestClientRouter, channel_send_after_end)
 {
-    using Msg     = ocvsmd::common::svc::node::ExecCmd::Request_0_1;
+    using Msg     = ocvsmd::common::svc::node::ExecCmd::Request_0_2;
     using Channel = Channel<Msg, Msg>;
 
     StrictMock<pipe::ClientPipeMock> client_pipe_mock;
@@ -282,7 +282,7 @@ TEST_F(TestClientRouter, channel_send_after_end)
 
 TEST_F(TestClientRouter, channel_receive_events)
 {
-    using Msg     = ocvsmd::common::svc::node::ExecCmd::Request_0_1;
+    using Msg     = ocvsmd::common::svc::node::ExecCmd::Request_0_2;
     using Channel = Channel<Msg, Msg>;
 
     StrictMock<pipe::ClientPipeMock> client_pipe_mock;
@@ -333,7 +333,7 @@ TEST_F(TestClientRouter, channel_receive_events)
 
 TEST_F(TestClientRouter, channel_unsolicited)
 {
-    using Msg     = ocvsmd::common::svc::node::ExecCmd::Request_0_1;
+    using Msg     = ocvsmd::common::svc::node::ExecCmd::Request_0_2;
     using Channel = Channel<Msg, Msg>;
 
     StrictMock<pipe::ClientPipeMock> client_pipe_mock;

--- a/test/common/ipc/test_client_router.cpp
+++ b/test/common/ipc/test_client_router.cpp
@@ -33,6 +33,7 @@ namespace
 {
 
 using namespace ocvsmd::common::ipc;  // NOLINT This our main concern here in the unit tests.
+using ocvsmd::sdk::ErrorCode;
 
 using testing::_;
 using testing::IsTrue;
@@ -69,7 +70,7 @@ protected:
 
         // client RouteConnect -> server
         EXPECT_CALL(client_pipe_mock, send(PayloadOfRouteConnect(mr_)))  //
-            .WillOnce(Return(0));
+            .WillOnce(Return(ErrorCode::Success));
         client_pipe_mock.event_handler_(pipe::ClientPipe::Event::Connected{});
 
         Route_0_2 route{&mr_};
@@ -78,11 +79,11 @@ protected:
         rt_conn.version.minor = ver_minor;
         rt_conn.error_code    = static_cast<std::int32_t>(error_code);
         //
-        const int result = tryPerformOnSerialized(route, [&](const auto payload) {
+        const auto result = tryPerformOnSerialized(route, [&](const auto payload) {
             //
             return client_pipe_mock.event_handler_(pipe::ClientPipe::Event::Message{payload});
         });
-        EXPECT_THAT(result, 0);
+        EXPECT_THAT(result, ErrorCode::Success);
     }
 
     template <typename Msg>
@@ -100,7 +101,7 @@ protected:
         channel_msg.sequence   = seq++;
         channel_msg.service_id = AnyChannel::getServiceDesc<Msg>(service_name).id;
 
-        const int result = tryPerformOnSerialized(route, [&](const auto prefix) {
+        const auto result = tryPerformOnSerialized(route, [&](const auto prefix) {
             //
             return tryPerformOnSerialized(msg, [&](const auto suffix) {
                 //
@@ -111,7 +112,7 @@ protected:
                 return client_pipe_mock.event_handler_(pipe::ClientPipe::Event::Message{payload});
             });
         });
-        EXPECT_THAT(result, 0);
+        EXPECT_THAT(result, ErrorCode::Success);
     }
 
     void emulateRouteChannelEnd(pipe::ClientPipeMock& client_pipe_mock,
@@ -127,11 +128,11 @@ protected:
         channel_end.error_code = static_cast<std::int32_t>(error_code);
         channel_end.keep_alive = keep_alive;
 
-        const int result = tryPerformOnSerialized(route, [&](const auto payload) {
+        const auto result = tryPerformOnSerialized(route, [&](const auto payload) {
             //
             return client_pipe_mock.event_handler_(pipe::ClientPipe::Event::Message{payload});
         });
-        EXPECT_THAT(result, 0);
+        EXPECT_THAT(result, ErrorCode::Success);
     }
 
     // MARK: Data members:
@@ -167,7 +168,7 @@ TEST_F(TestClientRouter, start)
     EXPECT_THAT(client_pipe_mock.event_handler_, IsFalse());
 
     EXPECT_CALL(client_pipe_mock, start(_)).Times(1);
-    EXPECT_THAT(client_router->start(), 0);
+    EXPECT_THAT(client_router->start(), ErrorCode::Success);
     EXPECT_THAT(client_pipe_mock.event_handler_, IsTrue());
 
     EXPECT_CALL(client_pipe_mock, deinit()).Times(1);
@@ -187,7 +188,7 @@ TEST_F(TestClientRouter, makeChannel)
     ASSERT_THAT(client_router, NotNull());
 
     EXPECT_CALL(client_pipe_mock, start(_)).Times(1);
-    EXPECT_THAT(client_router->start(), 0);
+    EXPECT_THAT(client_router->start(), ErrorCode::Success);
 
     const auto channel = client_router->makeChannel<Channel>();
     (void) channel;
@@ -207,7 +208,7 @@ TEST_F(TestClientRouter, channel_send)
     ASSERT_THAT(client_router, NotNull());
 
     EXPECT_CALL(client_pipe_mock, start(_)).Times(1);
-    EXPECT_THAT(client_router->start(), 0);
+    EXPECT_THAT(client_router->start(), ErrorCode::Success);
 
     auto channel = client_router->makeChannel<Channel>();
 
@@ -217,15 +218,15 @@ TEST_F(TestClientRouter, channel_send)
     std::uint64_t           seq = 0;
     const Msg               msg{&mr_};
     EXPECT_CALL(client_pipe_mock, send(PayloadOfRouteChannelMsg(msg, mr_, tag, seq++)))  //
-        .WillOnce(Return(0));
-    EXPECT_THAT(channel.send(msg), 0);
+        .WillOnce(Return(ErrorCode::Success));
+    EXPECT_THAT(channel.send(msg), ErrorCode::Success);
 
     EXPECT_CALL(client_pipe_mock, send(PayloadOfRouteChannelMsg(msg, mr_, tag, seq++)))  //
-        .WillOnce(Return(0));
-    EXPECT_THAT(channel.send(msg), 0);
+        .WillOnce(Return(ErrorCode::Success));
+    EXPECT_THAT(channel.send(msg), ErrorCode::Success);
 
     EXPECT_CALL(client_pipe_mock, send(PayloadOfRouteChannelEnd(mr_, tag, ErrorCode::Success)))  //
-        .WillOnce(Return(0));
+        .WillOnce(Return(ErrorCode::Success));
 }
 
 TEST_F(TestClientRouter, channel_send_after_end)
@@ -242,7 +243,7 @@ TEST_F(TestClientRouter, channel_send_after_end)
     ASSERT_THAT(client_router, NotNull());
 
     EXPECT_CALL(client_pipe_mock, start(_)).Times(1);
-    EXPECT_THAT(client_router->start(), 0);
+    EXPECT_THAT(client_router->start(), ErrorCode::Success);
 
     StrictMock<MockFunction<void(const Channel::EventVar&)>> ch_event_mock;
 
@@ -250,8 +251,8 @@ TEST_F(TestClientRouter, channel_send_after_end)
     channel.subscribe(ch_event_mock.AsStdFunction());
 
     const Msg msg{&mr_};
-    EXPECT_THAT(channel.send(msg), static_cast<int>(ErrorCode::NotConnected));
-    EXPECT_THAT(channel.complete(), static_cast<int>(ErrorCode::NotConnected));
+    EXPECT_THAT(channel.send(msg), ErrorCode::NotConnected);
+    EXPECT_THAT(channel.complete(), ErrorCode::NotConnected);
 
     EXPECT_CALL(ch_event_mock, Call(VariantWith<Channel::Connected>(_))).Times(1);
     emulateRouteConnect(client_pipe_mock);
@@ -264,20 +265,20 @@ TEST_F(TestClientRouter, channel_send_after_end)
 
     std::uint64_t seq = 0;
     EXPECT_CALL(client_pipe_mock, send(PayloadOfRouteChannelMsg(msg, mr_, tag, seq++)))  //
-        .WillOnce(Return(0));
-    EXPECT_THAT(channel.send(msg), 0);
+        .WillOnce(Return(ErrorCode::Success));
+    EXPECT_THAT(channel.send(msg), ErrorCode::Success);
     //
     EXPECT_CALL(client_pipe_mock, send(PayloadOfRouteChannelEnd(mr_, tag, ErrorCode::Success, true)))  //
-        .WillOnce(Return(0));
-    EXPECT_THAT(channel.complete(0, true), 0);
+        .WillOnce(Return(ErrorCode::Success));
+    EXPECT_THAT(channel.complete(ErrorCode::Success, true), ErrorCode::Success);
 
     // Emulate that server posted final `RouteChannelEnd(keep-alive)`.
     //
     EXPECT_CALL(ch_event_mock, Call(VariantWith<Channel::Completed>(_))).Times(1);
     emulateRouteChannelEnd(client_pipe_mock, tag, ErrorCode::Success, false);
 
-    EXPECT_THAT(channel.send(msg), static_cast<int>(ErrorCode::Shutdown));
-    EXPECT_THAT(channel.complete(), static_cast<int>(ErrorCode::Shutdown));
+    EXPECT_THAT(channel.send(msg), ErrorCode::Shutdown);
+    EXPECT_THAT(channel.complete(), ErrorCode::Shutdown);
 }
 
 TEST_F(TestClientRouter, channel_receive_events)
@@ -294,7 +295,7 @@ TEST_F(TestClientRouter, channel_receive_events)
     ASSERT_THAT(client_router, NotNull());
 
     EXPECT_CALL(client_pipe_mock, start(_)).Times(1);
-    EXPECT_THAT(client_router->start(), 0);
+    EXPECT_THAT(client_router->start(), ErrorCode::Success);
 
     StrictMock<MockFunction<void(const Channel::EventVar&)>> ch1_event_mock;
     StrictMock<MockFunction<void(const Channel::EventVar&)>> ch2_event_mock;
@@ -345,7 +346,7 @@ TEST_F(TestClientRouter, channel_unsolicited)
     ASSERT_THAT(client_router, NotNull());
 
     EXPECT_CALL(client_pipe_mock, start(_)).Times(1);
-    EXPECT_THAT(client_router->start(), 0);
+    EXPECT_THAT(client_router->start(), ErrorCode::Success);
 
     StrictMock<MockFunction<void(const Channel::EventVar&)>> ch_event_mock;
 

--- a/test/common/ipc/test_server_router.cpp
+++ b/test/common/ipc/test_server_router.cpp
@@ -13,7 +13,7 @@
 #include "tracking_memory_resource.hpp"
 
 #include "ocvsmd/common/ipc/Route_0_2.hpp"
-#include "ocvsmd/common/svc/node/ExecCmd_0_1.hpp"
+#include "ocvsmd/common/svc/node/ExecCmd_0_2.hpp"
 
 #include <cetl/pf17/cetlpf.hpp>
 
@@ -172,7 +172,7 @@ TEST_F(TestServerRouter, start)
 
 TEST_F(TestServerRouter, registerChannel)
 {
-    using Msg     = ocvsmd::common::svc::node::ExecCmd::Request_0_1;
+    using Msg     = ocvsmd::common::svc::node::ExecCmd::Request_0_2;
     using Channel = Channel<Msg, Msg>;
 
     StrictMock<pipe::ServerPipeMock> server_pipe_mock;
@@ -193,7 +193,7 @@ TEST_F(TestServerRouter, registerChannel)
 
 TEST_F(TestServerRouter, channel_send)
 {
-    using Msg     = ocvsmd::common::svc::node::ExecCmd::Request_0_1;
+    using Msg     = ocvsmd::common::svc::node::ExecCmd::Request_0_2;
     using Channel = Channel<Msg, Msg>;
 
     StrictMock<pipe::ServerPipeMock> server_pipe_mock;
@@ -259,7 +259,7 @@ TEST_F(TestServerRouter, channel_send)
 
 TEST_F(TestServerRouter, channel_send_after_end)
 {
-    using Msg     = ocvsmd::common::svc::node::ExecCmd::Request_0_1;
+    using Msg     = ocvsmd::common::svc::node::ExecCmd::Request_0_2;
     using Channel = Channel<Msg, Msg>;
 
     StrictMock<pipe::ServerPipeMock> server_pipe_mock;
@@ -337,7 +337,7 @@ TEST_F(TestServerRouter, channel_send_after_end)
 
 TEST_F(TestServerRouter, channel_disconnected)
 {
-    using Msg     = ocvsmd::common::svc::node::ExecCmd::Request_0_1;
+    using Msg     = ocvsmd::common::svc::node::ExecCmd::Request_0_2;
     using Channel = Channel<Msg, Msg>;
 
     StrictMock<pipe::ServerPipeMock> server_pipe_mock;
@@ -394,9 +394,9 @@ TEST_F(TestServerRouter, channel_disconnected)
 
 TEST_F(TestServerRouter, channel_unsolicited)
 {
-    using Msg           = ocvsmd::common::svc::node::ExecCmd::Request_0_1;
+    using Msg           = ocvsmd::common::svc::node::ExecCmd::Request_0_2;
     using Channel       = Channel<Msg, Msg>;
-    using UnexpectedMsg = ocvsmd::common::svc::node::ExecCmd::Response_0_1;
+    using UnexpectedMsg = ocvsmd::common::svc::node::ExecCmd::Response_0_2;
 
     StrictMock<pipe::ServerPipeMock> server_pipe_mock;
     EXPECT_CALL(server_pipe_mock, deinit()).Times(1);

--- a/test/daemon/engine/svc/node/test_exec_cmd_service.cpp
+++ b/test/daemon/engine/svc/node/test_exec_cmd_service.cpp
@@ -52,8 +52,9 @@ using std::literals::chrono_literals::operator""ms;
 class TestExecCmdService : public testing::Test
 {
 protected:
-    using ExecCmdSpec = svc::node::ExecCmdSpec;
-    using GatewayMock = ipc::detail::GatewayMock;
+    using ExecCmdSpec  = svc::node::ExecCmdSpec;
+    using GatewayMock  = ipc::detail::GatewayMock;
+    using GatewayEvent = ipc::detail::Gateway::Event;
 
     using CyService               = uavcan::node::ExecuteCommand_1_3;
     using CyPresentation          = libcyphal::presentation::Presentation;
@@ -162,15 +163,16 @@ TEST_F(TestExecCmdService, empty_request)
         const ExecCmdSpec::Request request{&mr_};
 
         EXPECT_CALL(gateway_mock, subscribe(_)).Times(1);
-        EXPECT_CALL(gateway_mock, complete(0, false)).Times(1);
-        EXPECT_CALL(gateway_mock, deinit()).Times(1);
-        //
         const auto result = tryPerformOnSerialized(request, [&](const auto payload) {
             //
             (*ch_factory)(std::move(gateway), payload);
             return 0;
         });
         EXPECT_THAT(result, 0);
+
+        EXPECT_CALL(gateway_mock, complete(0, false)).Times(1);
+        EXPECT_CALL(gateway_mock, deinit()).Times(1);
+        gateway_mock.event_handler_(GatewayEvent::Completed{ipc::ErrorCode::Success, true});
     }
 }
 
@@ -202,23 +204,31 @@ TEST_F(TestExecCmdService, two_nodes_request)
         //
         // Emulate service request.
         EXPECT_CALL(gateway_mock, subscribe(_)).Times(1);
-        expectCySvcSessions(cy_sess_42, 42);
-        expectCySvcSessions(cy_sess_43, 43);
         const auto result = tryPerformOnSerialized(request, [&](const auto payload) {
             //
             (*ch_factory)(std::make_shared<GatewayMock::Wrapper>(gateway_mock), payload);
             return 0;
         });
         EXPECT_THAT(result, 0);
+
+        expectCySvcSessions(cy_sess_42, 42);
+        expectCySvcSessions(cy_sess_43, 43);
+        gateway_mock.event_handler_(GatewayEvent::Completed{ipc::ErrorCode::Success, true});
     });
     scheduler_.scheduleAt(1s + 100ms, [&](const auto&) {
         //
         // Emulate that node 42 has responded in time (after 100ms).
         ExecCmdSpec::Response expected_response{&mr_};
-        expected_response.node_id = 42;
+        expected_response.error_code = 0;
+        expected_response.node_id    = 42;
         EXPECT_CALL(gateway_mock, send(_, ipc::PayloadWith<ExecCmdSpec::Response>(mr_, expected_response))).Times(1);
         CyServiceRxTransfer transfer{{{{0, libcyphal::transport::Priority::Nominal}, now()}, 42}, {}};
         cy_sess_42.res_rx_cb_fn({transfer});
+
+        // Node 43 never responded, so timeout is expected.
+        expected_response.error_code = ETIMEDOUT;
+        expected_response.node_id    = 43;
+        EXPECT_CALL(gateway_mock, send(_, ipc::PayloadWith<ExecCmdSpec::Response>(mr_, expected_response))).Times(1);
     });
     scheduler_.scheduleAt(2s, [&](const auto&) {
         //
@@ -255,18 +265,29 @@ TEST_F(TestExecCmdService, out_of_memory)
         request.node_ids.push_back(13);
         request.node_ids.push_back(31);
 
-        EXPECT_CALL(cy_transport_mock_, makeRequestTxSession(_)).WillOnce(Return(libcyphal::MemoryError{}));
+        EXPECT_CALL(cy_transport_mock_, makeRequestTxSession(_)).WillRepeatedly([] {
+            return libcyphal::MemoryError{};
+        });
 
         EXPECT_CALL(gateway_mock, subscribe(_)).Times(1);
-        EXPECT_CALL(gateway_mock, complete(ENOMEM, false)).Times(1);
-        EXPECT_CALL(gateway_mock, deinit()).Times(1);
-        //
         const auto result = tryPerformOnSerialized(request, [&](const auto payload) {
             //
             (*ch_factory)(std::move(gateway), payload);
             return 0;
         });
         EXPECT_THAT(result, 0);
+
+        ExecCmdSpec::Response expected_response{&mr_};
+        expected_response.error_code = ENOMEM;
+        expected_response.node_id    = 13;
+        EXPECT_CALL(gateway_mock, send(_, ipc::PayloadWith<ExecCmdSpec::Response>(mr_, expected_response))).Times(1);
+        expected_response.error_code = ENOMEM;
+        expected_response.node_id    = 31;
+        EXPECT_CALL(gateway_mock, send(_, ipc::PayloadWith<ExecCmdSpec::Response>(mr_, expected_response))).Times(1);
+
+        EXPECT_CALL(gateway_mock, complete(0, false)).Times(1);
+        EXPECT_CALL(gateway_mock, deinit()).Times(1);
+        gateway_mock.event_handler_(GatewayEvent::Completed{ipc::ErrorCode::Success, true});
     }
 }
 
@@ -284,13 +305,13 @@ namespace node
 {
 namespace ExecCmd
 {
-static void PrintTo(const Response_0_1& res, std::ostream* os)  // NOLINT
+static void PrintTo(const Response_0_2& res, std::ostream* os)  // NOLINT
 {
-    *os << "ExecCmd::Response_0_1{node_id=" << res.node_id << "}";
+    *os << "ExecCmd::Response_0_2{err=" << res.error_code << ", node_id=" << res.node_id << "}";
 }
-static bool operator==(const Response_0_1& lhs, const Response_0_1& rhs)  // NOLINT
+static bool operator==(const Response_0_2& lhs, const Response_0_2& rhs)  // NOLINT
 {
-    return lhs.node_id == rhs.node_id;
+    return (lhs.error_code == rhs.error_code) && (lhs.node_id == rhs.node_id);
 }
 }  // namespace ExecCmd
 }  // namespace node


### PR DESCRIPTION
Also:
- latest CETL
- reworked a bit execute command api:
  - now there is no partial success
  - no max 128 nodes limitation anymore
- reworked a bit list registers api:
  - no max 128 nodes limitation anymore