### PR TITLE
Daemon crashes when encountering timeout during register polling

### DIFF
--- a/src/common/ipc/pipe/socket_base.cpp
+++ b/src/common/ipc/pipe/socket_base.cpp
@@ -68,7 +68,7 @@ sdk::OptError SocketBase::send(const IoState& io_state, io::SocketBuffer& sock_b
     {
         if (const int err = platform::posixSyscallError([payload, &io_state] {
                 //
-                return ::send(io_state.fd.get(), payload.data(), payload.size(), MSG_DONTWAIT);
+                return ::send(io_state.fd.get(), payload.data(), payload.size(), MSG_DONTWAIT | MSG_NOSIGNAL);
             }))
         {
             logger_->error("SocketBase: Failed to send msg payload (fd={}): {}.",


### PR DESCRIPTION
Fixes #37 

We seem to have found a potential flaw in the OCVSMD daemon cleanup code that causes it to crash when we probe for a node's status register and receive a timeout error.

Upon further digging we found that:
When a service completes its request on the server side, it deconstructs the gateways involved with that request. However, in the gateway deconstructor, the function attempts to send a message to the client to notify it of the gateway deconstruction. In the specific edge case where the client disconnects and closes the socket, the sending of this message causes a SIGPIPE to be thrown, causing the daemon to crash.

Solution:
Added MSG_NOSIGNAL flag to socket base ::send function so that SIGPIPE isn't thrown when the socket to the client is closed, and instead logs a broken pipe error.